### PR TITLE
Add ability to use all `incident` attributes in message templates if `incident` is passed to a `form_message`

### DIFF
--- a/app/im/application.py
+++ b/app/im/application.py
@@ -72,7 +72,7 @@ class Application(ABC):
             unit = self.user_groups[identifier]
             unit_text = unit.mention_text(self.type, destinations)
         text = (
-            f'{self._format_text_citation(self.header_template.form_message(incident.last_state))}\n'
+            f'{self._format_text_citation(self.header_template.form_message(incident.last_state, incident))}\n'
             f'{unit_text}'
         )
         response_code = self._post_thread(incident.channel_id, incident.ts, text)
@@ -93,16 +93,16 @@ class Application(ABC):
             formatted_admins_text = self._format_text_citation(italic_admins_text)
             base_text += f'\n➤ admins: {formatted_admins_text}'
         text = (
-            f'{self._format_text_citation(self.header_template.form_message(incident.last_state))}\n'
+            f'{self._format_text_citation(self.header_template.form_message(incident.last_state, incident))}\n'
             f'{base_text}'
         )
 
         return self._post_thread(incident.channel_id, incident.ts, text)
 
     def update(self, uuid_, incident, incident_status, alert_state, updated_status, chain_enabled, status_enabled):
-        body = self.body_template.form_message(alert_state)
-        header = self.header_template.form_message(alert_state)
-        status_icons = self.status_icons_template.form_message(alert_state)
+        body = self.body_template.form_message(alert_state, incident)
+        header = self.header_template.form_message(alert_state, incident)
+        status_icons = self.status_icons_template.form_message(alert_state, incident)
         self.update_thread(
             incident.channel_id, incident.ts, incident_status, body, header, status_icons, chain_enabled, status_enabled
         )
@@ -111,7 +111,7 @@ class Application(ABC):
             # post to thread
             if status_enabled and incident_status != 'closed':
                 body = (
-                    f'{self._format_text_citation(self.header_template.form_message(incident.last_state))}\n'
+                    f'{self._format_text_citation(self.header_template.form_message(incident.last_state, incident))}\n'
                     f'➤ status: {self.format_text_bold(incident_status)}'
                 )
                 if incident_status == 'unknown':

--- a/app/im/mattermost/buttons.py
+++ b/app/im/mattermost/buttons.py
@@ -18,9 +18,9 @@ def mattermost_buttons_handler(app, payload, incidents, queue_):
         else:
             incident_.status_enabled = True
     incident_.dump()
-    status_icons = app.status_icons_template.form_message(incident_.last_state)
-    header = app.header_template.form_message(incident_.last_state)
-    message = app.body_template.form_message(incident_.last_state)
+    status_icons = app.status_icons_template.form_message(incident_.last_state, incident_)
+    header = app.header_template.form_message(incident_.last_state, incident_)
+    message = app.body_template.form_message(incident_.last_state, incident_)
     payload = mattermost_get_button_update_payload(
         message,
         header,

--- a/app/im/template.py
+++ b/app/im/template.py
@@ -1,22 +1,20 @@
 from jinja2 import Template
 
+from app.incident.incident import Incident
+
 
 class JinjaTemplate:
     def __init__(self, template):
         self.template = template
 
-    def form_message(self, alert_state):
+    def form_message(self, alert_state, incident: Incident = None):
         template = Template(self.template)
-        return template.render(payload=alert_state)
+        incident_data = incident.serialize() if incident else {}
+        return template.render(payload=alert_state, incident=incident_data)
 
 
-def generate_template(type_, body_dict=None, header_dict=None, status_icons_dict=None):
-    if type_ == 'slack':
-        incident_body = JinjaTemplate(body_dict)
-        incident_header = JinjaTemplate(header_dict)
-        incident_status_icons = JinjaTemplate(status_icons_dict)
-    else:
-        incident_body = JinjaTemplate(body_dict)
-        incident_header = JinjaTemplate(header_dict)
-        incident_status_icons = JinjaTemplate(status_icons_dict)
+def generate_template(body_dict=None, header_dict=None, status_icons_dict=None):
+    incident_body = JinjaTemplate(body_dict)
+    incident_header = JinjaTemplate(header_dict)
+    incident_status_icons = JinjaTemplate(status_icons_dict)
     return incident_body, incident_header, incident_status_icons

--- a/app/queue/handlers/step_handler.py
+++ b/app/queue/handlers/step_handler.py
@@ -25,7 +25,7 @@ class StepHandler(BaseHandler):
             webhook = self.webhooks.get(webhook_name)
             text = f'➤ webhook {self.app.format_text_bold(webhook_name)}: '
             if webhook is not None:
-                result, r_code = webhook.push()
+                result, r_code = webhook.push(incident)
                 self.app.notify_webhook(incident, text, result, response_code=r_code)
                 incident.chain_update(identifier, done=True, result=r_code)
                 logger.info(f'Notify webhook \'{webhook_name}\' result: \'{result}\', response code is {r_code}')

--- a/app/webhook.py
+++ b/app/webhook.py
@@ -4,34 +4,39 @@ import requests
 from jinja2 import Template
 from requests.auth import HTTPBasicAuth
 
+from app.incident.incident import Incident
+
 
 class Webhook:
     def __init__(self, url, data=None, auth=None):
-        self.url = self.render(url)
-        for k in data.keys():
-            data[k] = self.render(data[k])
-        self.data = data
-        self.auth = auth
+        self._url = self.render(url)
+        self._pre_render_data = data
+        self._auth = auth
 
-    def push(self):
-        if self.auth is not None:
-            u, p = self.auth.split(':')
+    def push(self, incident: Incident = None):
+        rendered_data = dict()
+        if self._pre_render_data:
+            serialized_incident = incident.serialize() if incident else dict()
+            for key, value in self._pre_render_data.items():
+                rendered_data[key] = self.render(value, incident=serialized_incident)
+        if self._auth is not None:
+            u, p = self._auth.split(':')
             auth = HTTPBasicAuth(self.render(u), self.render(p))
             try:
-                response = requests.post(url=self.url, data=self.data, auth=auth, timeout=1.0)
+                response = requests.post(url=self._url, data=rendered_data, auth=auth, timeout=1.0)
             except requests.exceptions.ConnectionError:
                 return f'Connection Error', None
         else:
             try:
-                response = requests.post(url=self.url, data=self.data, timeout=1.0)
+                response = requests.post(url=self._url, data=rendered_data, timeout=1.0)
             except requests.exceptions.ConnectionError:
                 return f'Connection Error', None
         return 'ok', response.status_code
 
     @staticmethod
-    def render(custom_string):
+    def render(custom_string, **kwargs):
         tmplt = Template(custom_string)
-        return tmplt.render(env=os.environ)
+        return tmplt.render(env=os.environ, **kwargs)
 
 
 def generate_webhooks(webhooks_dict=None):


### PR DESCRIPTION
- Added an ability to pass the `Incident` to the `form_message` to get any of it's serialized attributes within a template
- Added an ability to pass the `Incident` to the `push` method of the `Webhook` to get any of it's serialized attributes within a template
