### PR TITLE
A new User fetch logic

### DIFF
--- a/app/im/application.py
+++ b/app/im/application.py
@@ -59,7 +59,7 @@ class Application(ABC):
             return {}
 
         logger.info(f'Creating {self.type.capitalize()} users')
-        users_list = self._get_users()
+        users_list = self._get_users(users_dict)
 
         users = {}
         for name, user_info in users_dict.items():
@@ -254,7 +254,7 @@ class Application(ABC):
         pass
 
     @abstractmethod
-    def _get_users(self):
+    def _get_users(self, users):
         """Fetch users from the external system. Must be implemented by subclasses."""
         pass
 

--- a/app/im/mattermost/mattermost_application.py
+++ b/app/im/mattermost/mattermost_application.py
@@ -2,7 +2,6 @@ import json
 from time import sleep
 
 import requests
-from tomlkit import value
 
 from app.im.application import Application
 from app.im.colors import status_colors
@@ -82,7 +81,7 @@ class MattermostApplication(Application):
 
     def _get_users(self, users):
         usernames = [u['username'] for k, u in users.items()]
-        logger.info(f'Get users from Mattermost, usernames: {usernames}')
+        logger.info(f'Get users from Mattermost')
         try:
             response = self.http.post(
                 f'{self.url}/api/v4/users/usernames',

--- a/app/im/mattermost/mattermost_application.py
+++ b/app/im/mattermost/mattermost_application.py
@@ -2,6 +2,7 @@ import json
 from time import sleep
 
 import requests
+from tomlkit import value
 
 from app.im.application import Application
 from app.im.colors import status_colors
@@ -79,11 +80,13 @@ class MattermostApplication(Application):
         logger.warning(f"User '{username}' not found in Mattermost")
         return {'username': username, 'first_name': None, 'last_name': None}
 
-    def _get_users(self):
+    def _get_users(self, users):
+        usernames = [u['username'] for k, u in users.items()]
+        logger.info(f'Get users from Mattermost, usernames: {usernames}')
         try:
-            response = self.http.get(
-                f'{self.url}/api/v4/users',
-                params={'per_page': 200, 'active': True},
+            response = self.http.post(
+                f'{self.url}/api/v4/users/usernames',
+                data=json.dumps(usernames),
                 headers=self.headers
             )
             response.raise_for_status()

--- a/app/im/slack/slack_application.py
+++ b/app/im/slack/slack_application.py
@@ -60,15 +60,15 @@ class SlackApplication(Application):
         full_names = [u['full_name'] for k, u in users.items()]
         filtered_users = []
         request_data = {
-            'limit': 200,
-            'headers': self.headers
+            'limit': 50,
         }
-        logger.info(f'Get users from Slack, full names: {full_names}')
+        logger.info(f'Get users from Slack')
         try:
             while len(filtered_users) < len(full_names):
                 response = self.http.get(
                     f'{self.url}/api/users.list',
-                    **request_data
+                    data=request_data,
+                    headers=self.headers
                 )
                 response.raise_for_status()
                 sleep(slack_request_delay)

--- a/app/im/slack/slack_application.py
+++ b/app/im/slack/slack_application.py
@@ -56,16 +56,31 @@ class SlackApplication(Application):
         logger.warning(f"User '{full_name}' not found in Slack")
         return {'name': user_info.get('name'), 'slack_id': None}
 
-    def _get_users(self):
+    def _get_users(self, users):
+        full_names = [u['full_name'] for k, u in users.items()]
+        filtered_users = []
+        request_data = {
+            'limit': 200,
+            'headers': self.headers
+        }
+        logger.info(f'Get users from Slack, full names: {full_names}')
         try:
-            response = self.http.get(
-                f'{self.url}/api/users.list',
-                headers=self.headers
-            )
-            response.raise_for_status()
-            sleep(slack_request_delay)
-            json_data = response.json()
-            return json_data['members']
+            while len(filtered_users) < len(full_names):
+                response = self.http.get(
+                    f'{self.url}/api/users.list',
+                    **request_data
+                )
+                response.raise_for_status()
+                sleep(slack_request_delay)
+                json_data = response.json()
+                for user in json_data.get('members', []):
+                    if user.get('real_name') in full_names:
+                        filtered_users.append(user)
+                cursor = json_data.get('response_metadata', {}).get('next_cursor')
+                request_data.update({'cursor': cursor})
+                if not cursor:
+                    break
+            return filtered_users
         except requests.exceptions.RequestException as e:
             logger.error(f'Incorrect Slack response. Reason: {e}')
             raise UserGenerationError(f'Failed to retrieve users: {e}')


### PR DESCRIPTION
- Implemented a new way to fetch Users for Slack and Mattermost

Notes:
- Users for Mattermost are retrieved using POST request, retries won't  work for it in current configuration
- Users for Slack are retrieved using the regular GET but with pagination, so it could take some time to get all the needed users
- Currently if not all the users are available we just write a warning for each missing user