### PR TITLE
Fixed the Thread creation before an Incident

### DIFF
--- a/app/incident/incident.py
+++ b/app/incident/incident.py
@@ -20,7 +20,6 @@ class IncidentConfig:
 class Incident:
     last_state: Dict
     status: str
-    ts: str
     channel_id: str
     config: IncidentConfig
     chain: List[Dict] = field(default_factory=list)
@@ -30,7 +29,8 @@ class Incident:
     updated: datetime = datetime.utcnow()
     version: str = INCIDENT_ACTUAL_VERSION
     uuid: str = field(init=False)
-    link: str = field(init=False)
+    ts: str = field(default='')
+    link: str = field(default='')
 
     next_status = {
         'firing': 'unknown',
@@ -40,6 +40,9 @@ class Incident:
 
     def __post_init__(self):
         self.uuid = gen_uuid(self.last_state.get('groupLabels'))
+
+    def set_thread(self, thread_id: str):
+        self.ts = thread_id
         self.link = self.generate_link()
 
     def generate_link(self) -> str:
@@ -89,7 +92,6 @@ class Incident:
         incident = cls(
             last_state=content.get('last_state'),
             status=content.get('status'),
-            ts=content.get('ts'),
             channel_id=content.get('channel_id'),
             config=config,
             chain=content.get('chain', []),
@@ -99,6 +101,7 @@ class Incident:
             updated=content.get('updated'),
             version=content.get('version', INCIDENT_ACTUAL_VERSION)
         )
+        incident.set_thread(content.get('ts'))
         return incident
 
     def dump(self):
@@ -123,12 +126,12 @@ class Incident:
             "chain": self.chain,
             "channel_id": self.channel_id,
             "last_state": self.last_state,
-            "link": self.link,
             "status_enabled": self.status_enabled,
             "status_update_datetime": self.status_update_datetime,
             "status": self.status,
-            "ts": self.ts,
             "updated": self.updated,
+            "link": self.link,
+            "ts": self.ts,
         }
 
     def update_status(self, status: str) -> bool:

--- a/templates/mattermost_status_icons.j2
+++ b/templates/mattermost_status_icons.j2
@@ -1,3 +1,3 @@
-{%- set status = payload.get("status", "Unknown") -%}
-{%- set status_emoji = {"firing": ":fire:", "resolved": ":white_check_mark:"}[status] -%}
+{%- set status = incident.status -%}
+{%- set status_emoji = {"firing": ":fire:", "unknown": ":warning:", "resolved": ":white_check_mark:", "closed": ":heavy_multiplication_x:"}[status] -%}
 {{- status_emoji -}}

--- a/templates/slack_status_icons.j2
+++ b/templates/slack_status_icons.j2
@@ -1,3 +1,3 @@
-{%- set status = payload.get("status", "Unknown") -%}
-{%- set status_emoji = {"firing": ":fire:", "resolved": ":white_check_mark:"}[status] -%}
+{%- set status = incident.status -%}
+{%- set status_emoji = {"firing": ":fire:", "unknown": ":warning:", "resolved": ":white_check_mark:", "closed": ":heavy_multiplication_x:"}[status] -%}
 {{- status_emoji -}}


### PR DESCRIPTION
- Changed the Incident declaration to make `ts` and `link` - filled with `''` by default
- Added a `set_thread` function to fill the `ts` and `link` with actual data
- Changed the Icon templates