### PR TITLE
Removing the dynamic Slack URL

### DIFF
--- a/app/im/application.py
+++ b/app/im/application.py
@@ -18,6 +18,7 @@ class Application(ABC):
         self.http = self._setup_http()
         self.type = app_config['type']
         self.url = self.get_url(app_config)
+        self.public_url = self._get_public_url(app_config)
         self.team = self.get_team_name(app_config)
         self.chains = generate_chains(app_config.get('chains', dict()))
         self.templates = app_config.get('template_files', dict())
@@ -183,6 +184,11 @@ class Application(ABC):
 
     @abstractmethod
     def _get_url(self, app_config):
+        pass
+
+    @abstractmethod
+    def _get_public_url(self, app_config):
+        """Get the public URL of the application to share with users."""
         pass
 
     @abstractmethod

--- a/app/im/mattermost/mattermost_application.py
+++ b/app/im/mattermost/mattermost_application.py
@@ -78,6 +78,9 @@ class MattermostApplication(Application):
     def _get_url(self, app_config):
         return app_config['url']
 
+    def _get_public_url(self, app_config):
+        return app_config['url']
+
     def _get_team_name(self, app_config):
         logger.info(f'Get {self.type.capitalize()} team name')
         return app_config['team']

--- a/app/im/slack/slack_application.py
+++ b/app/im/slack/slack_application.py
@@ -20,7 +20,7 @@ class SlackApplication(Application):
         super().__init__(app_config, channels_list, default_channel)
 
     def _initialize_specific_params(self):
-        self.post_message_url = f'{self.url}/api/chat.postMessage'
+        self.post_message_url = f'{self.url}/chat.postMessage'
         self.headers = slack_headers
         self.post_delay = slack_request_delay
         self.thread_id_key = 'ts'
@@ -28,7 +28,7 @@ class SlackApplication(Application):
     def _get_public_channels(self) -> dict:
         try:
             response = self.http.get(
-                f'{self.url}/api/conversations.list',
+                f'{self.url}/conversations.list',
                 params={'limit': 1000},
                 headers=self.headers
             )
@@ -42,7 +42,7 @@ class SlackApplication(Application):
     def _get_private_channels(self) -> dict:
         try:
             response = self.http.get(
-                f'{self.url}/api/conversations.list',
+                f'{self.url}/conversations.list',
                 params={'types': 'private_channel', 'limit': 1000},
                 headers=self.headers
             )
@@ -54,13 +54,7 @@ class SlackApplication(Application):
             return {}
 
     def _get_url(self, app_config):
-        response = self.http.get(
-            f'https://slack.com/api/auth.test',
-            headers=slack_headers
-        )
-        sleep(slack_request_delay)
-        json_ = response.json()
-        return json_.get('url')
+        return 'https://slack.com/api'
 
     def _get_team_name(self, app_config):
         return None
@@ -86,7 +80,7 @@ class SlackApplication(Application):
         try:
             while len(filtered_users) < len(full_names):
                 response = self.http.get(
-                    f'{self.url}/api/users.list',
+                    f'{self.url}/users.list',
                     params=request_data,
                     headers=self.headers
                 )
@@ -144,7 +138,7 @@ class SlackApplication(Application):
                 }
             ]
         }
-        response = self.http.post(f'{self.url}/api/chat.postMessage', headers=self.headers, data=json.dumps(payload))
+        response = self.http.post(f'{self.url}/chat.postMessage', headers=self.headers, data=json.dumps(payload))
         sleep(self.post_delay)
         return response.json().get('ts')
 
@@ -161,7 +155,7 @@ class SlackApplication(Application):
 
     def _update_thread(self, id_, payload):
         requests.post(
-            f'{self.url}/api/chat.update',
+            f'{self.url}/chat.update',
             headers=slack_headers,
             data=json.dumps(payload)
         )

--- a/app/im/slack/slack_application.py
+++ b/app/im/slack/slack_application.py
@@ -20,7 +20,7 @@ class SlackApplication(Application):
         super().__init__(app_config, channels_list, default_channel)
 
     def _initialize_specific_params(self):
-        self.post_message_url = f'{self.url}/chat.postMessage'
+        self.post_message_url = f'{self.url}/api/chat.postMessage'
         self.headers = slack_headers
         self.post_delay = slack_request_delay
         self.thread_id_key = 'ts'
@@ -28,7 +28,7 @@ class SlackApplication(Application):
     def _get_public_channels(self) -> dict:
         try:
             response = self.http.get(
-                f'{self.url}/conversations.list',
+                f'{self.url}/api/conversations.list',
                 params={'limit': 1000},
                 headers=self.headers
             )
@@ -42,7 +42,7 @@ class SlackApplication(Application):
     def _get_private_channels(self) -> dict:
         try:
             response = self.http.get(
-                f'{self.url}/conversations.list',
+                f'{self.url}/api/conversations.list',
                 params={'types': 'private_channel', 'limit': 1000},
                 headers=self.headers
             )
@@ -54,7 +54,7 @@ class SlackApplication(Application):
             return {}
 
     def _get_url(self, app_config):
-        return 'https://slack.com/api'
+        return 'https://slack.com'
 
     def _get_public_url(self, app_config):
         response = self.http.get(
@@ -89,7 +89,7 @@ class SlackApplication(Application):
         try:
             while len(filtered_users) < len(full_names):
                 response = self.http.get(
-                    f'{self.url}/users.list',
+                    f'{self.url}/api/users.list',
                     params=request_data,
                     headers=self.headers
                 )
@@ -147,7 +147,7 @@ class SlackApplication(Application):
                 }
             ]
         }
-        response = self.http.post(f'{self.url}/chat.postMessage', headers=self.headers, data=json.dumps(payload))
+        response = self.http.post(f'{self.url}/api/chat.postMessage', headers=self.headers, data=json.dumps(payload))
         sleep(self.post_delay)
         return response.json().get('ts')
 
@@ -164,7 +164,7 @@ class SlackApplication(Application):
 
     def _update_thread(self, id_, payload):
         requests.post(
-            f'{self.url}/chat.update',
+            f'{self.url}/api/chat.update',
             headers=slack_headers,
             data=json.dumps(payload)
         )

--- a/app/im/slack/slack_application.py
+++ b/app/im/slack/slack_application.py
@@ -56,6 +56,15 @@ class SlackApplication(Application):
     def _get_url(self, app_config):
         return 'https://slack.com/api'
 
+    def _get_public_url(self, app_config):
+        response = self.http.get(
+            f'https://slack.com/api/auth.test',
+            headers=slack_headers
+        )
+        sleep(slack_request_delay)
+        json_ = response.json()
+        return json_.get('url')
+
     def _get_team_name(self, app_config):
         return None
 

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ application = get_application(
     route.channel
 )
 webhooks = generate_webhooks(webhooks_dict)
-incidents = Incidents.create_or_load(application.type, application.url, application.team)
+incidents = Incidents.create_or_load(application.type, application.public_url, application.team)
 queue = Queue.recreate_queue(incidents, check_updates)
 
 queue_manager = QueueManager(queue, application, incidents, webhooks, route)


### PR DESCRIPTION
Quite a strange change as @DiTsi introduced this.
In general - just hardcoding the Slak URL