### PR TITLE
Fix Telegram link generation

### DIFF
--- a/app/incident/incident.py
+++ b/app/incident/incident.py
@@ -55,8 +55,7 @@ class Incident:
         elif self.config.application_type == 'mattermost':
             return f'{self.config.application_url}/{self.config.application_team.lower()}/pl/{self.ts}'
         elif self.config.application_type == 'telegram':
-            # TODO: Fix this as it won't work for Telegram (self.channel_id isn't the id that needed there)
-            return f'https://t.me/c/{self.channel_id}/{self.ts}'
+            return f'https://t.me/c/{str(self.channel_id)[4:]}/{self.ts}'
         return ''
 
     def generate_chain(self, chain=None):


### PR DESCRIPTION
This pull request includes a fix for generating Telegram links in the `generate_link` method of the `Incident` class. The change ensures that the correct format for `channel_id` is used when constructing the Telegram URL.

Key change:
* [`app/incident/incident.py`](diffhunk://#diff-a90945c229ac7b7a493b21c74eb25a1ad5d48b1d75b07e19c83a5bb0e593ee5aL58-R58): Fixed the Telegram link generation by slicing the `channel_id` to remove the first four characters, as the previous implementation used an incorrect format.