### PR TITLE
Refactor Webhook push method to use RetryClient

### DIFF
--- a/app/queue/handlers/step_handler.py
+++ b/app/queue/handlers/step_handler.py
@@ -30,11 +30,7 @@ class StepHandler(BaseHandler):
             admins = self.app.get_notification_destinations()
 
             if webhook is not None:
-                # Pass the app's HTTP session to the webhook if available
-                if hasattr(self.app, 'http') and self.app.http:
-                    result, r_code = await webhook.push(incident, session=self.app.http)
-                else:
-                    result, r_code = await webhook.push(incident)
+                result, r_code = await webhook.push(incident)
                 fields = {'type': self.app.type, 'name': webhook_name, 'unit': webhook, 'admins': admins,
                           'result': result, 'response': r_code}
                 incident.chain_update(identifier, done=True, result=r_code)

--- a/app/webhook.py
+++ b/app/webhook.py
@@ -3,7 +3,8 @@ import os
 from typing import Dict
 
 import aiohttp
-from aiohttp import BasicAuth
+from aiohttp import BasicAuth, ClientTimeout
+from aiohttp_retry import ExponentialRetry, RetryClient
 from jinja2 import Template
 
 from app.config.validation import WebhookConfig
@@ -18,19 +19,23 @@ class Webhook:
         self._json_payload = json_payload
         self._auth = auth
 
-    async def push(self, incident: Incident = None, session: aiohttp.ClientSession = None):
+    async def push(self, incident: Incident = None):
         rendered_data = self._render_data(incident)
         rendered_json = self._render_json(incident)
         auth = self._get_auth() if self._auth else None
 
-        # Use provided session or create a temporary one
-        if session:
-            return await self._make_request(session, rendered_data, rendered_json, auth)
-        else:
-            async with aiohttp.ClientSession() as temp_session:
-                return await self._make_request(temp_session, rendered_data, rendered_json, auth)
+        retry_options = ExponentialRetry(
+            attempts=3,
+            start_timeout=1.0,
+            max_timeout=10.0,
+            statuses={500, 502, 503, 504}
+        )
+        timeout = ClientTimeout(total=30.0)
+        async with aiohttp.ClientSession(timeout=timeout) as temp_session:
+            retry_client = RetryClient(client_session=temp_session, retry_options=retry_options)
+            return await self._make_request(retry_client, rendered_data, rendered_json, auth)
 
-    async def _make_request(self, session: aiohttp.ClientSession, rendered_data, rendered_json, auth):
+    async def _make_request(self, session, rendered_data, rendered_json, auth):
         try:
             timeout = aiohttp.ClientTimeout(total=5.0)
             request_params = {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,1 @@
-sonar.exclusions=tests/**
-sonar.test.exclusions=tests/**
+sonar.exclusions=tests/**/*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,2 @@
+sonar.exclusions=tests/**
+sonar.test.exclusions=tests/**

--- a/tests/test_queue/test_handlers.py
+++ b/tests/test_queue/test_handlers.py
@@ -391,47 +391,12 @@ class TestStepHandler:
         mock_webhook.push = AsyncMock(return_value=('ok', 200))
         mock_webhooks.get.return_value = mock_webhook
 
-        # Mock application without HTTP session
-        mock_application.http = None
-
         await step_handler.handle(incident_uuid, identifier)
 
         # Should execute webhook and update chain
         mock_webhook.push.assert_called_once_with(mock_incident)
         mock_incident.chain_update.assert_called_once_with(identifier, done=True, result=200)
         mock_application.post_thread.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_handle_webhook_step_with_http_session(self, step_handler, mock_incidents, mock_application,
-                                                         mock_webhooks):
-        """Test handling webhook step with HTTP session."""
-        incident_uuid = 'incident123'
-        identifier = 0
-
-        # Mock incident with webhook step
-        mock_incident = Mock()
-        mock_incident.uuid = incident_uuid
-        mock_incident.channel_id = 'C123456789'
-        mock_incident.ts = '1234567890.123456'
-        mock_incident.payload = {'alertname': 'TestAlert'}
-        mock_incident.chain = [
-            {'type': 'webhook', 'identifier': 'test-webhook', 'done': False}
-        ]
-        mock_incident.chain_update = Mock()
-        mock_incidents.by_uuid[incident_uuid] = mock_incident
-
-        # Mock webhook
-        mock_webhook = Mock()
-        mock_webhook.push = AsyncMock(return_value=('ok', 200))
-        mock_webhooks.get.return_value = mock_webhook
-
-        # Mock application with HTTP session
-        mock_application.http = Mock()
-
-        await step_handler.handle(incident_uuid, identifier)
-
-        # Should execute webhook with session
-        mock_webhook.push.assert_called_once_with(mock_incident, session=mock_application.http)
 
     @pytest.mark.asyncio
     async def test_handle_webhook_step_undefined(self, step_handler, mock_incidents, mock_application, mock_webhooks):

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -2,7 +2,7 @@
 Unit tests for the Webhook class and related functionality.
 """
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import aiohttp
 import pytest
@@ -11,7 +11,11 @@ from aiohttp import ClientSession, BasicAuth
 from app.config.validation import WebhookConfig
 from app.incident.incident import Incident, IncidentConfig
 from app.webhook import Webhook, generate_webhooks
-from tests.utils import setup_mock_session_class_patch
+from tests.utils import (
+    setup_mock_session_class_patch,
+    create_error_context_manager,
+    setup_mock_webhook_with_retry_client
+)
 
 
 class TestWebhook:
@@ -88,57 +92,74 @@ class TestWebhook:
         assert webhook._auth == "user:pass"
 
     @pytest.mark.asyncio
-    async def test_push_with_session_form_data(self, mock_session, sample_incident):
-        """Test push method with form data using provided session."""
-        data = {"message": "Alert: {{ incident.payload.alertname }}"}
-        webhook = Webhook("https://example.com/webhook", data=data)
+    async def test_push_with_session_form_data(self, sample_incident):
+        """Test push method with form data."""
+        with patch('aiohttp.ClientSession') as mock_session_class, \
+             patch('app.webhook.RetryClient') as mock_retry_client_class:
+            mock_retry_client = setup_mock_session_class_patch(mock_session_class, 200)
+            mock_retry_client_class.return_value = mock_retry_client
+            
+            data = {"message": "Alert: {{ incident.payload.alertname }}"}
+            webhook = Webhook("https://example.com/webhook", data=data)
 
-        result = await webhook.push(incident=sample_incident, session=mock_session)
+            result = await webhook.push(incident=sample_incident)
 
-        assert result == ('ok', 200)
-        mock_session.post.assert_called_once()
+            assert result == ('ok', 200)
+            mock_retry_client.post.assert_called_once()
 
-        # Verify the call was made with form data
-        call_args = mock_session.post.call_args
-        assert call_args[1]['data'] == {"message": "Alert: TestAlert"}
-
-    @pytest.mark.asyncio
-    async def test_push_with_session_json_dict(self, mock_session, sample_incident):
-        """Test push method with JSON dict using provided session."""
-        json_payload = {"message": "Alert: {{ incident.payload.alertname }}",
-                        "severity": "{{ incident.payload.severity }}"}
-        webhook = Webhook("https://example.com/webhook", json_payload=json_payload)
-
-        result = await webhook.push(incident=sample_incident, session=mock_session)
-
-        assert result == ('ok', 200)
-        mock_session.post.assert_called_once()
-
-        # Verify the call was made with JSON data
-        call_args = mock_session.post.call_args
-        assert call_args[1]['json'] == {"message": "Alert: TestAlert", "severity": "critical"}
+            # Verify the call was made with form data
+            call_args = mock_retry_client.post.call_args
+            assert call_args[1]['data'] == {"message": "Alert: TestAlert"}
 
     @pytest.mark.asyncio
-    async def test_push_with_session_json_string(self, mock_session, sample_incident):
-        """Test push method with JSON string using provided session."""
-        json_payload = '{"message": "Alert: {{ incident.payload.alertname }}"}'
-        webhook = Webhook("https://example.com/webhook", json_payload=json_payload)
+    async def test_push_with_session_json_dict(self, sample_incident):
+        """Test push method with JSON dict."""
+        with patch('aiohttp.ClientSession') as mock_session_class, \
+             patch('app.webhook.RetryClient') as mock_retry_client_class:
+            mock_retry_client = setup_mock_session_class_patch(mock_session_class, 200)
+            mock_retry_client_class.return_value = mock_retry_client
+            
+            json_payload = {"message": "Alert: {{ incident.payload.alertname }}",
+                            "severity": "{{ incident.payload.severity }}"}
+            webhook = Webhook("https://example.com/webhook", json_payload=json_payload)
 
-        result = await webhook.push(incident=sample_incident, session=mock_session)
+            result = await webhook.push(incident=sample_incident)
 
-        assert result == ('ok', 200)
-        mock_session.post.assert_called_once()
+            assert result == ('ok', 200)
+            mock_retry_client.post.assert_called_once()
 
-        # Verify the call was made with JSON string
-        call_args = mock_session.post.call_args
-        assert call_args[1]['data'] == '{"message": "Alert: TestAlert"}'
-        assert call_args[1]['headers']['Content-Type'] == 'application/json'
+            # Verify the call was made with JSON data
+            call_args = mock_retry_client.post.call_args
+            assert call_args[1]['json'] == {"message": "Alert: TestAlert", "severity": "critical"}
+
+    @pytest.mark.asyncio
+    async def test_push_with_session_json_string(self, sample_incident):
+        """Test push method with JSON string."""
+        with patch('aiohttp.ClientSession') as mock_session_class, \
+             patch('app.webhook.RetryClient') as mock_retry_client_class:
+            mock_retry_client = setup_mock_session_class_patch(mock_session_class, 200)
+            mock_retry_client_class.return_value = mock_retry_client
+            
+            json_payload = '{"message": "Alert: {{ incident.payload.alertname }}"}'
+            webhook = Webhook("https://example.com/webhook", json_payload=json_payload)
+
+            result = await webhook.push(incident=sample_incident)
+
+            assert result == ('ok', 200)
+            mock_retry_client.post.assert_called_once()
+
+            # Verify the call was made with JSON string
+            call_args = mock_retry_client.post.call_args
+            assert call_args[1]['data'] == '{"message": "Alert: TestAlert"}'
+            assert call_args[1]['headers']['Content-Type'] == 'application/json'
 
     @pytest.mark.asyncio
     async def test_push_without_session(self, sample_incident):
         """Test push method without provided session (creates temporary session)."""
-        with patch('aiohttp.ClientSession') as mock_session_class:
-            setup_mock_session_class_patch(mock_session_class, 200)
+        with patch('aiohttp.ClientSession') as mock_session_class, \
+             patch('app.webhook.RetryClient') as mock_retry_client_class:
+            mock_retry_client = setup_mock_session_class_patch(mock_session_class, 200)
+            mock_retry_client_class.return_value = mock_retry_client
 
             webhook = Webhook("https://example.com/webhook", data={"message": "test"})
             result = await webhook.push(incident=sample_incident)
@@ -147,45 +168,103 @@ class TestWebhook:
             mock_session_class.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_push_with_auth(self, mock_session, sample_incident):
+    async def test_push_with_auth(self, sample_incident):
         """Test push method with authentication."""
-        webhook = Webhook("https://example.com/webhook", data={"message": "test"}, auth="user:pass")
+        with patch('aiohttp.ClientSession') as mock_session_class, \
+             patch('app.webhook.RetryClient') as mock_retry_client_class:
+            mock_retry_client = setup_mock_session_class_patch(mock_session_class, 200)
+            mock_retry_client_class.return_value = mock_retry_client
+            
+            webhook = Webhook("https://example.com/webhook", data={"message": "test"}, auth="user:pass")
 
-        result = await webhook.push(incident=sample_incident, session=mock_session)
+            result = await webhook.push(incident=sample_incident)
 
-        assert result == ('ok', 200)
-        call_args = mock_session.post.call_args
-        assert isinstance(call_args[1]['auth'], BasicAuth)
+            assert result == ('ok', 200)
+            call_args = mock_retry_client.post.call_args
+            assert isinstance(call_args[1]['auth'], BasicAuth)
 
     @pytest.mark.asyncio
-    async def test_make_request_timeout_error(self, mock_session, sample_incident):
+    async def test_make_request_timeout_error(self, sample_incident):
         """Test _make_request method with timeout error."""
-        mock_session.post.side_effect = asyncio.TimeoutError()
+        with patch('aiohttp.ClientSession') as mock_session_class, \
+             patch('app.webhook.RetryClient') as mock_retry_client_class:
+            
+            mock_retry_client = AsyncMock()
+            mock_retry_client.post = Mock(return_value=create_error_context_manager(asyncio.TimeoutError()))
+            mock_retry_client_class.return_value = mock_retry_client
+            
+            mock_session = AsyncMock()
+            mock_session.__aenter__.return_value = mock_session
+            mock_session.__aexit__.return_value = None
+            mock_session_class.return_value = mock_session
+            
+            webhook = Webhook("https://example.com/webhook", data={"message": "test"})
+            result = await webhook.push(incident=sample_incident)
 
-        webhook = Webhook("https://example.com/webhook", data={"message": "test"})
-        result = await webhook.push(incident=sample_incident, session=mock_session)
-
-        assert result == ('Timeout', None)
+            assert result == ('Timeout', None)
 
     @pytest.mark.asyncio
-    async def test_make_request_connection_error(self, mock_session, sample_incident):
+    async def test_make_request_connection_error(self, sample_incident):
         """Test _make_request method with connection error."""
-        mock_session.post.side_effect = aiohttp.ClientConnectionError()
+        with patch('aiohttp.ClientSession') as mock_session_class, \
+             patch('app.webhook.RetryClient') as mock_retry_client_class:
+            
+            mock_retry_client = AsyncMock()
+            mock_retry_client.post = Mock(return_value=create_error_context_manager(aiohttp.ClientConnectionError()))
+            mock_retry_client_class.return_value = mock_retry_client
+            
+            mock_session = AsyncMock()
+            mock_session.__aenter__.return_value = mock_session
+            mock_session.__aexit__.return_value = None
+            mock_session_class.return_value = mock_session
+            
+            webhook = Webhook("https://example.com/webhook", data={"message": "test"})
+            result = await webhook.push(incident=sample_incident)
 
-        webhook = Webhook("https://example.com/webhook", data={"message": "test"})
-        result = await webhook.push(incident=sample_incident, session=mock_session)
-
-        assert result == ('ConnectionError', None)
+            assert result == ('ConnectionError', None)
 
     @pytest.mark.asyncio
-    async def test_make_request_client_error(self, mock_session, sample_incident):
+    async def test_make_request_client_error(self, sample_incident):
         """Test _make_request method with client error."""
-        mock_session.post.side_effect = aiohttp.ClientError("Test error")
+        with patch('aiohttp.ClientSession') as mock_session_class, \
+             patch('app.webhook.RetryClient') as mock_retry_client_class:
+            
+            mock_retry_client = AsyncMock()
+            mock_retry_client.post = Mock(return_value=create_error_context_manager(aiohttp.ClientError("Test error")))
+            mock_retry_client_class.return_value = mock_retry_client
+            
+            mock_session = AsyncMock()
+            mock_session.__aenter__.return_value = mock_session
+            mock_session.__aexit__.return_value = None
+            mock_session_class.return_value = mock_session
+            
+            webhook = Webhook("https://example.com/webhook", data={"message": "test"})
+            result = await webhook.push(incident=sample_incident)
 
-        webhook = Webhook("https://example.com/webhook", data={"message": "test"})
-        result = await webhook.push(incident=sample_incident, session=mock_session)
+            assert result == ('ClientError', None)
 
-        assert result == ('ClientError', None)
+    @pytest.mark.asyncio
+    async def test_push_with_retry_on_server_errors(self, sample_incident):
+        """Test push method retries on 500, 502, 503, 504 status codes."""
+        with patch('aiohttp.ClientSession') as mock_session_class, \
+             patch('app.webhook.RetryClient') as mock_retry_client_class:
+            
+            setup_mock_webhook_with_retry_client(
+                mock_session_class, mock_retry_client_class, 200
+            )
+            
+            webhook = Webhook("https://example.com/webhook", data={"message": "test"})
+            result = await webhook.push(incident=sample_incident)
+            
+            # Verify RetryClient was created with ExponentialRetry configured for server errors
+            mock_retry_client_class.assert_called_once()
+            call_args = mock_retry_client_class.call_args
+            retry_options = call_args[1]['retry_options']
+            
+            # Verify retry is configured for server error status codes
+            assert retry_options.statuses == {500, 502, 503, 504}
+            assert retry_options.attempts == 3
+            assert result == ('ok', 200)
 
     def test_render_data_with_incident(self, sample_incident):
         """Test _render_data method with incident."""
@@ -384,8 +463,10 @@ class TestWebhookIntegration:
     @pytest.mark.asyncio
     async def test_complete_webhook_flow_form_data(self, sample_incident):
         """Test complete webhook flow with form data."""
-        with patch('aiohttp.ClientSession') as mock_session_class:
-            mock_session, _ = setup_mock_session_class_patch(mock_session_class, 201)
+        with patch('aiohttp.ClientSession') as mock_session_class, \
+             patch('app.webhook.RetryClient') as mock_retry_client_class:
+            mock_retry_client = setup_mock_session_class_patch(mock_session_class, 201)
+            mock_retry_client_class.return_value = mock_retry_client
 
             webhook = Webhook(
                 url="https://example.com/webhook",
@@ -399,10 +480,10 @@ class TestWebhookIntegration:
             result = await webhook.push(incident=sample_incident)
 
             assert result == ('ok', 201)
-            mock_session.post.assert_called_once()
+            mock_retry_client.post.assert_called_once()
 
             # Verify the call parameters
-            call_args = mock_session.post.call_args
+            call_args = mock_retry_client.post.call_args
             assert call_args[1]['url'] == "https://example.com/webhook"
             assert call_args[1]['data'] == {
                 "alert": "TestAlert",
@@ -413,8 +494,10 @@ class TestWebhookIntegration:
     @pytest.mark.asyncio
     async def test_complete_webhook_flow_json_dict(self, sample_incident):
         """Test complete webhook flow with JSON dict."""
-        with patch('aiohttp.ClientSession') as mock_session_class:
-            mock_session, _ = setup_mock_session_class_patch(mock_session_class, 200)
+        with patch('aiohttp.ClientSession') as mock_session_class, \
+             patch('app.webhook.RetryClient') as mock_retry_client_class:
+            mock_retry_client = setup_mock_session_class_patch(mock_session_class, 200)
+            mock_retry_client_class.return_value = mock_retry_client
 
             webhook = Webhook(
                 url="https://example.com/webhook",
@@ -427,10 +510,10 @@ class TestWebhookIntegration:
             result = await webhook.push(incident=sample_incident)
 
             assert result == ('ok', 200)
-            mock_session.post.assert_called_once()
+            mock_retry_client.post.assert_called_once()
 
             # Verify the call parameters
-            call_args = mock_session.post.call_args
+            call_args = mock_retry_client.post.call_args
             assert call_args[1]['url'] == "https://example.com/webhook"
             assert call_args[1]['json'] == {
                 "alert": "TestAlert",
@@ -440,8 +523,10 @@ class TestWebhookIntegration:
     @pytest.mark.asyncio
     async def test_complete_webhook_flow_json_string(self, sample_incident):
         """Test complete webhook flow with JSON string."""
-        with patch('aiohttp.ClientSession') as mock_session_class:
-            mock_session, _ = setup_mock_session_class_patch(mock_session_class, 200)
+        with patch('aiohttp.ClientSession') as mock_session_class, \
+             patch('app.webhook.RetryClient') as mock_retry_client_class:
+            mock_retry_client = setup_mock_session_class_patch(mock_session_class, 200)
+            mock_retry_client_class.return_value = mock_retry_client
 
             webhook = Webhook(
                 url="https://example.com/webhook",
@@ -451,10 +536,10 @@ class TestWebhookIntegration:
             result = await webhook.push(incident=sample_incident)
 
             assert result == ('ok', 200)
-            mock_session.post.assert_called_once()
+            mock_retry_client.post.assert_called_once()
 
             # Verify the call parameters
-            call_args = mock_session.post.call_args
+            call_args = mock_retry_client.post.call_args
             assert call_args[1]['url'] == "https://example.com/webhook"
             assert call_args[1]['data'] == '{"alert": "TestAlert"}'
             assert call_args[1]['headers']['Content-Type'] == 'application/json'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -79,25 +79,37 @@ def create_mock_session_class_with_response(status_code=200):
     return mock_session_class, mock_session, mock_response
 
 
-def setup_mock_session_class_patch(mock_session_class, status_code=200):
+def setup_mock_session_class_patch(mock_session_class, status_code=200, patch_retry_client=True):
     """
     Setup a mock session class patch with a configured response.
     
     Args:
         mock_session_class: The mock session class from patch
         status_code: HTTP status code for the mock response (default: 200)
+        patch_retry_client: Whether to return retry client mock (default: True)
         
     Returns:
-        tuple: (mock_session, mock_response)
+        mock_retry_client: The mock RetryClient instance (if patch_retry_client=True)
+        tuple: (mock_session, mock_response) if patch_retry_client=False (legacy behavior)
     """
     mock_response = AsyncMock()
     mock_response.status = status_code
 
+    # Mock the base session
     mock_session = AsyncMock()
-    mock_session.post = Mock(return_value=MockContextManager(mock_response))
-    mock_session_class.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+    mock_session_class.return_value = mock_session
 
-    return mock_session, mock_response
+    if patch_retry_client:
+        # Mock RetryClient with the response for webhook tests
+        mock_retry_client = AsyncMock()
+        mock_retry_client.post = Mock(return_value=MockContextManager(mock_response))
+        return mock_retry_client
+    else:
+        # Legacy behavior for non-webhook tests
+        mock_session.post = Mock(return_value=MockContextManager(mock_response))
+        return mock_session, mock_response
 
 
 # ============================================================================
@@ -1108,6 +1120,52 @@ class FakeTime:
             seconds: Number of seconds to sleep
         """
         self.advance(seconds)
+
+
+def create_error_context_manager(error):
+    """
+    Create an async context manager that raises an error on entry.
+    
+    Args:
+        error: The error to raise when entering the context
+        
+    Returns:
+        Error context manager class
+    """
+    class ErrorContextManager:
+        async def __aenter__(self):
+            raise error
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            pass
+    return ErrorContextManager()
+
+
+def setup_mock_webhook_with_retry_client(mock_session_class, mock_retry_client_class, status_code=200):
+    """
+    Setup mock session and RetryClient for webhook tests.
+    
+    Args:
+        mock_session_class: The mock ClientSession class from patch
+        mock_retry_client_class: The mock RetryClient class from patch
+        status_code: HTTP status code for the mock response (default: 200)
+        
+    Returns:
+        Tuple of (mock_retry_client, mock_response)
+    """
+    mock_response = AsyncMock()
+    mock_response.status = status_code
+    
+    mock_retry_client = AsyncMock()
+    from unittest.mock import Mock
+    mock_retry_client.post = Mock(return_value=MockContextManager(mock_response))
+    mock_retry_client_class.return_value = mock_retry_client
+    
+    mock_session = AsyncMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+    mock_session_class.return_value = mock_session
+    
+    return mock_retry_client, mock_response
 
 
 def create_test_server_url(server, path: str = '/test') -> str:


### PR DESCRIPTION
- Removed session parameter, ensuring a temporary session is always created.
- Updated tests to reflect changes in the push method and added retry logic verification.