### PR TITLE
354 add prometheus metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 
 env*
 venv*
+.venv*
 
 .env
 .coverage

--- a/app/http_client/rate_limited_client.py
+++ b/app/http_client/rate_limited_client.py
@@ -8,7 +8,7 @@ from aiohttp import ClientTimeout, ClientSession, ClientResponse
 from aiohttp_retry import ExponentialRetry, RetryClient
 
 from app.logging import logger
-from app.metrics import measure_metrics, metrics_messenger_api_request_duration_seconds
+from app.metrics import measure_request
 
 
 class RetryAfterRetry(ExponentialRetry):
@@ -80,12 +80,10 @@ class RateLimitedClient:
         retry_attempts: int = 3,
         timeout: float = 30.0,
         connector_limit: int = 100,
-        connector_limit_per_host: int = 30,
-        messenger: Optional[str] = None
+        connector_limit_per_host: int = 30
     ):
         self.rate_limit = rate_limit
         self.rate_window = rate_window
-        self.messenger = messenger or 'none'
         
         # Rate limiting state
         self._request_count = 0
@@ -198,6 +196,7 @@ class RateLimitedClient:
             self._request_count += 1
             self._last_request_time = time.monotonic()
     
+    @measure_request
     async def request(self, method: str, url: str, **kwargs):
         """
         Make an HTTP request with rate limiting and metrics tracking.
@@ -213,56 +212,53 @@ class RateLimitedClient:
         self._initialize_client()
         await self._wait_for_rate_limit()
         
-        async with measure_metrics(
-            messenger=self.messenger,
-            histogram=metrics_messenger_api_request_duration_seconds,
-        ) as context:
-            try:
-                response = await self._client.request(method, url, **kwargs)
-                status_code = response.status
-                context['status'] = f'{status_code // 100}xx'
-                context['error'] = 'none'
-                logger.info(f"Request to {url} completed with status {status_code} ({context['status']})")
-                return response
-            
-            except asyncio.TimeoutError as e:
-                context['error'] = 'timeout'
-                logger.error(f"Request to {url} timed out: {type(e).__name__}: {e}")
-                raise e
+        try:
+            response = await self._client.request(method, url, **kwargs)
+            return response
 
-            except aiohttp.ClientConnectorError as e:
-                context['error'] = 'connection_failed'
-                logger.error(f"Request to {url} connection failed: {type(e).__name__}: {e}")
-                raise
+        except asyncio.TimeoutError as e:
+            logger.error(
+                f"Request to {url} timed out: {type(e).__name__}: {e}"
+            )
+            raise
 
-            except Exception as e:
-                logger.error(f"Request to {url} failed: {type(e).__name__}: {e}")
-                raise
+        except aiohttp.ClientConnectorError as e:
+            logger.error(
+                f"Request to {url} connection failed: "
+                f"{type(e).__name__}: {e}"
+            )
+            raise
+
+        except Exception as e:
+            logger.error(
+                f"Request to {url} failed: {type(e).__name__}: {e}"
+            )
+            raise
     
     async def get(self, url: str, **kwargs):
         """Make a GET request with rate limiting"""
         return await self.request('GET', url, **kwargs)
-    
+
     async def post(self, url: str, **kwargs):
         """Make a POST request with rate limiting"""
         return await self.request('POST', url, **kwargs)
-    
+
     async def put(self, url: str, **kwargs):
         """Make a PUT request with rate limiting"""
         return await self.request('PUT', url, **kwargs)
-    
+
     async def delete(self, url: str, **kwargs):
         """Make a DELETE request with rate limiting"""
         return await self.request('DELETE', url, **kwargs)
-    
+
     async def patch(self, url: str, **kwargs):
         """Make a PATCH request with rate limiting"""
         return await self.request('PATCH', url, **kwargs)
-    
+
     async def head(self, url: str, **kwargs):
         """Make a HEAD request with rate limiting"""
         return await self.request('HEAD', url, **kwargs)
-    
+
     async def options(self, url: str, **kwargs):
         """Make an OPTIONS request with rate limiting"""
         return await self.request('OPTIONS', url, **kwargs)

--- a/app/http_client/rate_limited_client.py
+++ b/app/http_client/rate_limited_client.py
@@ -211,8 +211,7 @@ class RateLimitedClient:
         """
         self._initialize_client()
         await self._wait_for_rate_limit()
-        response = await self._client.request(method, url, **kwargs)
-        return response
+        return await self._client.request(method, url, **kwargs)
     
     async def get(self, url: str, **kwargs):
         """Make a GET request with rate limiting"""

--- a/app/http_client/rate_limited_client.py
+++ b/app/http_client/rate_limited_client.py
@@ -8,7 +8,7 @@ from aiohttp import ClientTimeout, ClientSession, ClientResponse
 from aiohttp_retry import ExponentialRetry, RetryClient
 
 from app.logging import logger
-from app.metrics import measure_request
+from app.metrics import MetricsCollector
 
 
 class RetryAfterRetry(ExponentialRetry):
@@ -195,8 +195,8 @@ class RateLimitedClient:
             # Increment request counter
             self._request_count += 1
             self._last_request_time = time.monotonic()
-    
-    @measure_request
+
+    @MetricsCollector.measure_request
     async def request(self, method: str, url: str, **kwargs):
         """
         Make an HTTP request with rate limiting and metrics tracking.
@@ -217,22 +217,12 @@ class RateLimitedClient:
             return response
 
         except asyncio.TimeoutError as e:
-            logger.error(
-                f"Request to {url} timed out: {type(e).__name__}: {e}"
-            )
             raise
 
         except aiohttp.ClientConnectorError as e:
-            logger.error(
-                f"Request to {url} connection failed: "
-                f"{type(e).__name__}: {e}"
-            )
             raise
 
         except Exception as e:
-            logger.error(
-                f"Request to {url} failed: {type(e).__name__}: {e}"
-            )
             raise
     
     async def get(self, url: str, **kwargs):

--- a/app/http_client/rate_limited_client.py
+++ b/app/http_client/rate_limited_client.py
@@ -8,7 +8,7 @@ from aiohttp import ClientTimeout, ClientSession, ClientResponse
 from aiohttp_retry import ExponentialRetry, RetryClient
 
 from app.logging import logger
-from app.metrics import MetricsCollector
+from app.metrics import measure_request
 
 
 class RetryAfterRetry(ExponentialRetry):
@@ -196,7 +196,7 @@ class RateLimitedClient:
             self._request_count += 1
             self._last_request_time = time.monotonic()
 
-    @MetricsCollector.measure_request
+    @measure_request
     async def request(self, method: str, url: str, **kwargs):
         """
         Make an HTTP request with rate limiting and metrics tracking.

--- a/app/http_client/rate_limited_client.py
+++ b/app/http_client/rate_limited_client.py
@@ -8,7 +8,7 @@ from aiohttp import ClientTimeout, ClientSession, ClientResponse
 from aiohttp_retry import ExponentialRetry, RetryClient
 
 from app.logging import logger
-from app.metrics import api_response_time_seconds, measure_metrics
+from app.metrics import measure_metrics, metrics_messenger_api_request_duration_seconds
 
 
 class RetryAfterRetry(ExponentialRetry):
@@ -81,11 +81,11 @@ class RateLimitedClient:
         timeout: float = 30.0,
         connector_limit: int = 100,
         connector_limit_per_host: int = 30,
-        messenger_type: Optional[str] = None
+        messenger: Optional[str] = None
     ):
         self.rate_limit = rate_limit
         self.rate_window = rate_window
-        self.messenger_type = messenger_type or 'none'
+        self.messenger = messenger or 'none'
         
         # Rate limiting state
         self._request_count = 0
@@ -214,23 +214,28 @@ class RateLimitedClient:
         await self._wait_for_rate_limit()
         
         async with measure_metrics(
-            messenger_type=self.messenger_type,
-            histogram=api_response_time_seconds,
+            messenger=self.messenger,
+            histogram=metrics_messenger_api_request_duration_seconds,
         ) as context:
             try:
                 response = await self._client.request(method, url, **kwargs)
                 status_code = response.status
-                context['status_class'] = f'{status_code // 100}xx'
-                logger.info(f"Request to {url} completed with status {status_code} ({context['status_class']})")
+                context['status'] = f'{status_code // 100}xx'
+                context['error'] = 'none'
+                logger.info(f"Request to {url} completed with status {status_code} ({context['status']})")
                 return response
             
             except asyncio.TimeoutError as e:
-                context['status_class'] = 'timeout'
+                context['error'] = 'timeout'
                 logger.error(f"Request to {url} timed out: {type(e).__name__}: {e}")
                 raise e
 
+            except aiohttp.ClientConnectorError as e:
+                context['error'] = 'connection_failed'
+                logger.error(f"Request to {url} connection failed: {type(e).__name__}: {e}")
+                raise
+
             except Exception as e:
-                context['status_class'] = 'error'
                 logger.error(f"Request to {url} failed: {type(e).__name__}: {e}")
                 raise
     
@@ -281,4 +286,3 @@ class RateLimitedClient:
             'window_start_time': self._window_start_time,
             'last_request_time': self._last_request_time
         }
-

--- a/app/http_client/rate_limited_client.py
+++ b/app/http_client/rate_limited_client.py
@@ -211,19 +211,8 @@ class RateLimitedClient:
         """
         self._initialize_client()
         await self._wait_for_rate_limit()
-        
-        try:
-            response = await self._client.request(method, url, **kwargs)
-            return response
-
-        except asyncio.TimeoutError as e:
-            raise
-
-        except aiohttp.ClientConnectorError as e:
-            raise
-
-        except Exception as e:
-            raise
+        response = await self._client.request(method, url, **kwargs)
+        return response
     
     async def get(self, url: str, **kwargs):
         """Make a GET request with rate limiting"""

--- a/app/http_client/rate_limited_client.py
+++ b/app/http_client/rate_limited_client.py
@@ -1,4 +1,5 @@
 import asyncio
+
 import time
 from typing import Optional
 
@@ -7,6 +8,7 @@ from aiohttp import ClientTimeout, ClientSession, ClientResponse
 from aiohttp_retry import ExponentialRetry, RetryClient
 
 from app.logging import logger
+from app.metrics import api_response_time_seconds, measure_metrics
 
 
 class RetryAfterRetry(ExponentialRetry):
@@ -78,10 +80,12 @@ class RateLimitedClient:
         retry_attempts: int = 3,
         timeout: float = 30.0,
         connector_limit: int = 100,
-        connector_limit_per_host: int = 30
+        connector_limit_per_host: int = 30,
+        messenger_type: Optional[str] = None
     ):
         self.rate_limit = rate_limit
         self.rate_window = rate_window
+        self.messenger_type = messenger_type or 'none'
         
         # Rate limiting state
         self._request_count = 0
@@ -196,7 +200,7 @@ class RateLimitedClient:
     
     async def request(self, method: str, url: str, **kwargs):
         """
-        Make an HTTP request with rate limiting.
+        Make an HTTP request with rate limiting and metrics tracking.
 
         Args:
             method: HTTP method (GET, POST, PUT, DELETE, etc.)
@@ -209,7 +213,26 @@ class RateLimitedClient:
         self._initialize_client()
         await self._wait_for_rate_limit()
         
-        return await self._client.request(method, url, **kwargs)
+        async with measure_metrics(
+            messenger_type=self.messenger_type,
+            histogram=api_response_time_seconds,
+        ) as context:
+            try:
+                response = await self._client.request(method, url, **kwargs)
+                status_code = response.status
+                context['status_class'] = f'{status_code // 100}xx'
+                logger.info(f"Request to {url} completed with status {status_code} ({context['status_class']})")
+                return response
+            
+            except asyncio.TimeoutError as e:
+                context['status_class'] = 'timeout'
+                logger.error(f"Request to {url} timed out: {type(e).__name__}: {e}")
+                raise e
+
+            except Exception as e:
+                context['status_class'] = 'error'
+                logger.error(f"Request to {url} failed: {type(e).__name__}: {e}")
+                raise
     
     async def get(self, url: str, **kwargs):
         """Make a GET request with rate limiting"""

--- a/app/im/application.py
+++ b/app/im/application.py
@@ -310,8 +310,7 @@ class Application(ABC):
             retry_attempts=3,
             timeout=30.0,
             connector_limit=100,
-            connector_limit_per_host=30,
-            messenger=self.type.value  # Messenger type for metrics
+            connector_limit_per_host=30
         )
 
         # Initialize the client

--- a/app/im/application.py
+++ b/app/im/application.py
@@ -310,7 +310,8 @@ class Application(ABC):
             retry_attempts=3,
             timeout=30.0,
             connector_limit=100,
-            connector_limit_per_host=30
+            connector_limit_per_host=30,
+            messenger_type=self.type.value  # Messenger type for metrics
         )
 
         # Initialize the client

--- a/app/im/application.py
+++ b/app/im/application.py
@@ -311,7 +311,7 @@ class Application(ABC):
             timeout=30.0,
             connector_limit=100,
             connector_limit_per_host=30,
-            messenger_type=self.type.value  # Messenger type for metrics
+            messenger=self.type.value  # Messenger type for metrics
         )
 
         # Initialize the client

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -1,0 +1,31 @@
+"""Prometheus metrics for IMPulse application."""
+import time
+from contextlib import asynccontextmanager
+
+from prometheus_client import Histogram
+
+
+@asynccontextmanager
+async def measure_metrics(*, messenger_type: str, histogram: Histogram):
+    """
+    Async context manager to measure elapsed time and increment counters.
+    """
+    start = time.perf_counter()
+    context = {'status_class': 'error'}
+    try:
+        yield context
+    finally:
+        duration = time.perf_counter() - start
+        status = context.get('status_class', 'error')
+        histogram.labels(
+            messenger_type=messenger_type,
+            status_class=status
+        ).observe(duration)
+
+
+api_response_time_seconds = Histogram(
+    'api_response_time_seconds',
+    'HTTP response time for messenger API requests',
+    ['messenger_type', 'status_class'],
+    buckets=[0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, float('inf')]
+)

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -15,6 +15,7 @@ from prometheus_client import (
 from fastapi.responses import Response
 
 from app.config.config import get_config
+from app.queue.queue import AsyncQueue
 
 
 class MetricsCollector:
@@ -51,11 +52,12 @@ class MetricsCollector:
             'Last observed delay between scheduled queue task and Prometheus scrape time'
         )
 
-    def measure_request(self, func):
+    @classmethod
+    def measure_request(cls, func):
         """
         Measure HTTP request duration and track status/errors.
         """
-        collector = self
+        collector = cls()
 
         @wraps(func)
         async def wrapper(instance, *args, **kwargs):
@@ -83,9 +85,7 @@ class MetricsCollector:
 
             finally:
                 duration = time.perf_counter() - start
-                histogram = (
-                    collector.messenger_api_request_duration_seconds
-                )
+                histogram = collector.messenger_api_request_duration_seconds
                 histogram.labels(
                     messenger=messenger_type,
                     status=status,
@@ -94,17 +94,13 @@ class MetricsCollector:
 
         return wrapper
 
-    async def update_queue_latency(self, queue):
+    async def update_queue_latency(self, queue: AsyncQueue):
         """
         Update queue latency metric based on first item in queue.
 
         Args:
             queue: AsyncQueue instance to check for latency
         """
-        if queue is None:
-            self.queue_latency_seconds.set(0.0)
-            return
-
         first_item_datetime = await queue.get_first_item_datetime()
 
         if first_item_datetime is None:
@@ -114,37 +110,19 @@ class MetricsCollector:
             delay = max(0, (now - first_item_datetime).total_seconds())
             self.queue_latency_seconds.set(delay)
 
-    async def generate_metrics_response(self, queue=None) -> Response:
+    async def generate_metrics_response(self, queue: AsyncQueue) -> Response:
         """
         Generate Prometheus metrics response.
 
         Args:
-            queue: Optional AsyncQueue instance to update queue latency metric
+            queue: Optional AsyncQueue instance to update queue latency metric.
+                   If None (standby mode), queue latency will be set to 0.0.
 
         Returns:
             FastAPI Response with metrics content
         """
-        if queue is not None:
-            await self.update_queue_latency(queue)
+        await self.update_queue_latency(queue)
         return Response(
             content=generate_latest(),
             media_type=CONTENT_TYPE_LATEST
         )
-
-
-metrics_collector = MetricsCollector()
-
-metrics_messenger_api_request_duration_seconds = (
-    metrics_collector.messenger_api_request_duration_seconds
-)
-metrics_status = metrics_collector.status
-metrics_queue_latency_seconds = metrics_collector.queue_latency_seconds
-
-
-def measure_request(func):
-    """
-    Measure HTTP request duration and track status/errors.
-
-    Decorator function that wraps MetricsCollector.measure_request.
-    """
-    return metrics_collector.measure_request(func)

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -2,7 +2,7 @@
 import time
 from contextlib import asynccontextmanager
 
-from prometheus_client import Histogram
+from prometheus_client import Gauge, Histogram
 
 
 @asynccontextmanager
@@ -24,8 +24,13 @@ async def measure_metrics(*, messenger_type: str, histogram: Histogram):
 
 
 api_response_time_seconds = Histogram(
-    'api_response_time_seconds',
+    'impulse_api_response_time_seconds',
     'HTTP response time for messenger API requests',
     ['messenger_type', 'status_class'],
     buckets=[0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, float('inf')]
+)
+
+impulse_status = Gauge(
+    'impulse_status',
+    'IMPulse instance status (1.0=primary, 0.0=standby)'
 )

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -3,126 +3,108 @@ import asyncio
 import time
 from datetime import datetime, timezone
 from functools import wraps
-from typing import Optional
 
 import aiohttp
 from prometheus_client import (
+    CollectorRegistry,
+    CONTENT_TYPE_LATEST,
     Gauge,
     Histogram,
-    generate_latest,
-    CONTENT_TYPE_LATEST
+    generate_latest
 )
 from fastapi.responses import Response
 
-from app.config.config import get_config
 from app.queue.queue import AsyncQueue
 
+# Create a separate registry for our metrics only
+registry = CollectorRegistry()
 
-class MetricsCollector:
-    """Singleton class for collecting and exposing Prometheus metrics."""
 
-    _instance: Optional['MetricsCollector'] = None
+# Metrics definitions
+API_LATENCY = Histogram(
+    'impulse_messenger_http_request_duration_seconds',
+    'Duration of HTTP requests to messenger API',
+    ['status', 'error'],
+    buckets=[0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, float('inf')],
+    registry=registry,
+)
 
-    def __new__(cls):
-        """Create or return existing singleton instance."""
-        if cls._instance is None:
-            cls._instance = super(MetricsCollector, cls).__new__(cls)
-            cls._instance._initialized = False
-        return cls._instance
+STATUS = Gauge(
+    'impulse_status',
+    'IMPulse instance mode (1 - primary, 0 - standby)',
+    registry=registry,
+)
 
-    def __init__(self):
-        if self._initialized:
-            return
+QUEUE_LATENCY = Gauge(
+    'impulse_queue_latency_seconds',
+    'Delay in execution of the first queue item',
+    registry=registry,
+)
 
-        self._initialized = True
-        self.messenger_api_request_duration_seconds = Histogram(
-            'impulse_messenger_api_request_duration_seconds',
-            'Request duration to messenger API',
-            ['messenger', 'status', 'error'],
-            buckets=[
-                0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, float('inf')
-            ]
-        )
-        self.status = Gauge(
-            'impulse_status',
-            'IMPulse instance status (1.0=primary, 0.0=standby)'
-        )
-        self.queue_latency_seconds = Gauge(
-            'impulse_queue_latency_seconds',
-            'Last observed delay between scheduled queue task and Prometheus scrape time'
-        )
 
-    @classmethod
-    def measure_request(cls, func):
-        """
-        Measure HTTP request duration and track status/errors.
-        """
-        collector = cls()
+def measure_request(func):
+    """
+    Decorator to measure HTTP request duration and track status/errors.
+    """
+    @wraps(func)
+    async def wrapper(instance, *args, **kwargs):
+        start = time.perf_counter()
+        status = 'no_response'
+        error = 'unknown'
 
-        @wraps(func)
-        async def wrapper(instance, *args, **kwargs):
-            config = get_config()
-            messenger_type = config.messenger.type.value
+        try:
+            response = await func(instance, *args, **kwargs)
+            status = f'{response.status // 100}xx'
+            error = 'none'
+            return response
 
-            start = time.perf_counter()
-            status = 'no_response'
-            error = 'unknown'
+        except asyncio.TimeoutError:
+            error = 'timeout'
+            raise
 
-            try:
-                response = await func(instance, *args, **kwargs)
-                status_code = response.status
-                status = f'{status_code // 100}xx'
-                error = 'none'
-                return response
+        except aiohttp.ClientConnectorError:
+            error = 'connection_failed'
+            raise
 
-            except asyncio.TimeoutError:
-                error = 'timeout'
-                raise
+        finally:
+            duration = time.perf_counter() - start
+            API_LATENCY.labels(
+                status=status,
+                error=error
+            ).observe(duration)
 
-            except aiohttp.ClientConnectorError:
-                error = 'connection_failed'
-                raise
+    return wrapper
 
-            finally:
-                duration = time.perf_counter() - start
-                histogram = collector.messenger_api_request_duration_seconds
-                histogram.labels(
-                    messenger=messenger_type,
-                    status=status,
-                    error=error
-                ).observe(duration)
 
-        return wrapper
+async def update_queue_latency(queue: AsyncQueue):
+    """
+    Update queue latency metric based on first item in queue.
 
-    async def update_queue_latency(self, queue: AsyncQueue):
-        """
-        Update queue latency metric based on first item in queue.
+    Args:
+        queue: AsyncQueue instance to check for latency
+    """
+    first_item_datetime = await queue.get_first_item_datetime()
 
-        Args:
-            queue: AsyncQueue instance to check for latency
-        """
-        first_item_datetime = await queue.get_first_item_datetime()
+    if first_item_datetime is None:
+        QUEUE_LATENCY.set(0.0)
+    else:
+        now = datetime.now(timezone.utc)
+        delay = max(0, (now - first_item_datetime).total_seconds())
+        QUEUE_LATENCY.set(delay)
 
-        if first_item_datetime is None:
-            self.queue_latency_seconds.set(0.0)
-        else:
-            now = datetime.now(timezone.utc)
-            delay = max(0, (now - first_item_datetime).total_seconds())
-            self.queue_latency_seconds.set(delay)
 
-    async def generate_metrics_response(self, queue: AsyncQueue) -> Response:
-        """
-        Generate Prometheus metrics response.
+async def generate_metrics_response(queue: AsyncQueue) -> Response:
+    """
+    Generate Prometheus metrics response.
 
-        Args:
-            queue: Optional AsyncQueue instance to update queue latency metric.
-                   If None (standby mode), queue latency will be set to 0.0.
+    Args:
+        queue: AsyncQueue instance to update queue latency metric.
 
-        Returns:
-            FastAPI Response with metrics content
-        """
-        await self.update_queue_latency(queue)
-        return Response(
-            content=generate_latest(),
-            media_type=CONTENT_TYPE_LATEST
-        )
+    Returns:
+        FastAPI Response with metrics content
+    """
+    await update_queue_latency(queue)
+    return Response(
+        content=generate_latest(registry),
+        media_type=CONTENT_TYPE_LATEST
+    )

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -1,46 +1,153 @@
 """Prometheus metrics for IMPulse application."""
+import asyncio
 import time
-from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from functools import wraps
+from typing import Optional
 
-from prometheus_client import Gauge, Histogram
+import aiohttp
+from prometheus_client import (
+    Gauge,
+    Histogram,
+    generate_latest,
+    CONTENT_TYPE_LATEST
+)
+from fastapi.responses import Response
+
+from app.config.config import get_config
 
 
-@asynccontextmanager
-async def measure_metrics(*, messenger: str, histogram: Histogram):
+class MetricsCollector:
+    """Singleton class for collecting and exposing Prometheus metrics."""
+
+    _instance: Optional['MetricsCollector'] = None
+
+    def __new__(cls):
+        """Create or return existing singleton instance."""
+        if cls._instance is None:
+            cls._instance = super(MetricsCollector, cls).__new__(cls)
+            cls._instance._initialized = False
+        return cls._instance
+
+    def __init__(self):
+        if self._initialized:
+            return
+
+        self._initialized = True
+        self.messenger_api_request_duration_seconds = Histogram(
+            'impulse_messenger_api_request_duration_seconds',
+            'Request duration to messenger API',
+            ['messenger', 'status', 'error'],
+            buckets=[
+                0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, float('inf')
+            ]
+        )
+        self.status = Gauge(
+            'impulse_status',
+            'IMPulse instance status (1.0=primary, 0.0=standby)'
+        )
+        self.queue_latency_seconds = Gauge(
+            'impulse_queue_latency_seconds',
+            'Last observed delay between scheduled queue task and Prometheus scrape time'
+        )
+
+    def measure_request(self, func):
+        """
+        Measure HTTP request duration and track status/errors.
+        """
+        collector = self
+
+        @wraps(func)
+        async def wrapper(instance, *args, **kwargs):
+            config = get_config()
+            messenger_type = config.messenger.type.value
+
+            start = time.perf_counter()
+            status = 'no_response'
+            error = 'unknown'
+
+            try:
+                response = await func(instance, *args, **kwargs)
+                status_code = response.status
+                status = f'{status_code // 100}xx'
+                error = 'none'
+                return response
+
+            except asyncio.TimeoutError:
+                error = 'timeout'
+                raise
+
+            except aiohttp.ClientConnectorError:
+                error = 'connection_failed'
+                raise
+
+            except Exception:
+                raise
+
+            finally:
+                duration = time.perf_counter() - start
+                histogram = (
+                    collector.messenger_api_request_duration_seconds
+                )
+                histogram.labels(
+                    messenger=messenger_type,
+                    status=status,
+                    error=error
+                ).observe(duration)
+
+        return wrapper
+
+    async def update_queue_latency(self, queue):
+        """
+        Update queue latency metric based on first item in queue.
+
+        Args:
+            queue: AsyncQueue instance to check for latency
+        """
+        if queue is None:
+            self.queue_latency_seconds.set(0.0)
+            return
+
+        first_item_datetime = await queue.get_first_item_datetime()
+
+        if first_item_datetime is None:
+            self.queue_latency_seconds.set(0.0)
+        else:
+            now = datetime.now(timezone.utc)
+            delay = max(0, (now - first_item_datetime).total_seconds())
+            self.queue_latency_seconds.set(delay)
+
+    async def generate_metrics_response(self, queue=None) -> Response:
+        """
+        Generate Prometheus metrics response.
+
+        Args:
+            queue: Optional AsyncQueue instance to update queue latency metric
+
+        Returns:
+            FastAPI Response with metrics content
+        """
+        if queue is not None:
+            await self.update_queue_latency(queue)
+        return Response(
+            content=generate_latest(),
+            media_type=CONTENT_TYPE_LATEST
+        )
+
+
+metrics_collector = MetricsCollector()
+
+metrics_messenger_api_request_duration_seconds = (
+    metrics_collector.messenger_api_request_duration_seconds
+)
+metrics_status = metrics_collector.status
+metrics_queue_latency_seconds = metrics_collector.queue_latency_seconds
+
+
+def measure_request(func):
     """
-    Async context manager to measure elapsed time and increment counters.
-    Yields a mutable context dict:
-        context['status'] -> '1xx'|'2xx'|'3xx'|'4xx'|'5xx'|'no_response' (no_response = non-HTTP error)
-        context['error']  -> 'none'|'connection_failed'|'timeout'|'unknown'
+    Measure HTTP request duration and track status/errors.
+
+    Decorator function that wraps MetricsCollector.measure_request.
     """
-    start = time.perf_counter()
-    context = {'status': 'no_response', 'error': 'unknown'}
-    try:
-        yield context
-    finally:
-        duration = time.perf_counter() - start
-        status = context.get('status', 'no_response')
-        error = context.get('error', 'unknown')
-        histogram.labels(
-            messenger=messenger,
-            status=status,
-            error=error
-        ).observe(duration)
-
-
-metrics_messenger_api_request_duration_seconds = Histogram(
-    'impulse_messenger_api_request_duration_seconds',
-    'Request duration to messenger API',
-    ['messenger', 'status', 'error'],
-    buckets=[0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, float('inf')]
-)
-
-metrics_status = Gauge(
-    'impulse_status',
-    'IMPulse instance status (1.0=primary, 0.0=standby)'
-)
-
-metrics_queue_latency_seconds = Gauge(
-    'impulse_queue_latency_seconds',
-    'Delay between scheduled and actual processing time for queue items'
-)
+    return metrics_collector.measure_request(func)

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -6,36 +6,41 @@ from prometheus_client import Gauge, Histogram
 
 
 @asynccontextmanager
-async def measure_metrics(*, messenger_type: str, histogram: Histogram):
+async def measure_metrics(*, messenger: str, histogram: Histogram):
     """
     Async context manager to measure elapsed time and increment counters.
+    Yields a mutable context dict:
+        context['status'] -> '1xx'|'2xx'|'3xx'|'4xx'|'5xx'|'no_response' (no_response = non-HTTP error)
+        context['error']  -> 'none'|'connection_failed'|'timeout'|'unknown'
     """
     start = time.perf_counter()
-    context = {'status_class': 'error'}
+    context = {'status': 'no_response', 'error': 'unknown'}
     try:
         yield context
     finally:
         duration = time.perf_counter() - start
-        status = context.get('status_class', 'error')
+        status = context.get('status', 'no_response')
+        error = context.get('error', 'unknown')
         histogram.labels(
-            messenger_type=messenger_type,
-            status_class=status
+            messenger=messenger,
+            status=status,
+            error=error
         ).observe(duration)
 
 
-api_response_time_seconds = Histogram(
-    'impulse_api_response_time_seconds',
-    'HTTP response time for messenger API requests',
-    ['messenger_type', 'status_class'],
+metrics_messenger_api_request_duration_seconds = Histogram(
+    'impulse_messenger_api_request_duration_seconds',
+    'Request duration to messenger API',
+    ['messenger', 'status', 'error'],
     buckets=[0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, float('inf')]
 )
 
-impulse_status = Gauge(
+metrics_status = Gauge(
     'impulse_status',
     'IMPulse instance status (1.0=primary, 0.0=standby)'
 )
 
-queue_delay_seconds = Gauge(
-    'impulse_queue_delay_seconds',
+metrics_queue_latency_seconds = Gauge(
+    'impulse_queue_latency_seconds',
     'Delay between scheduled and actual processing time for queue items'
 )

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -34,3 +34,8 @@ impulse_status = Gauge(
     'impulse_status',
     'IMPulse instance status (1.0=primary, 0.0=standby)'
 )
+
+queue_delay_seconds = Gauge(
+    'impulse_queue_delay_seconds',
+    'Delay between scheduled and actual processing time for queue items'
+)

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -81,9 +81,6 @@ class MetricsCollector:
                 error = 'connection_failed'
                 raise
 
-            except Exception:
-                raise
-
             finally:
                 duration = time.perf_counter() - start
                 histogram = (

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -20,7 +20,7 @@ def service_unavailable_response(message: str) -> Response:
 
 
 class StandbyMiddleware(BaseHTTPMiddleware):
-    """Middleware to block all requests except /readyz and /livez when in standby mode"""
+    """Middleware to block all requests except /readyz, /livez and /metrics when in standby mode"""
     
     async def dispatch(self, request: Request, call_next):
         path = request.url.path
@@ -31,9 +31,9 @@ class StandbyMiddleware(BaseHTTPMiddleware):
         config_data = get_config()
         http_prefix = config_data.http_prefix or ""
         
-        # Check if path is /readyz or /livez (with or without prefix)
+        # Check if path is /readyz, /livez or /metrics (with or without prefix)
         # Endpoints are registered directly in app with prefix, so check full path
-        if path == f"{http_prefix}/readyz" or path == f"{http_prefix}/livez":
+        if path == f"{http_prefix}/readyz" or path == f"{http_prefix}/livez" or path == f"{http_prefix}/metrics":
             return await call_next(request)
         
         # Check if server is in standby mode
@@ -49,7 +49,7 @@ class StandbyMiddleware(BaseHTTPMiddleware):
                 return await call_next(request)
             
             # Block all other requests
-            return service_unavailable_response("Service Unavailable - Standby mode. Only /readyz and /livez endpoints are available.")
+            return service_unavailable_response("Service Unavailable - Standby mode. Only /readyz, /livez and /metrics endpoints are available.")
         
         return await call_next(request)
 

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -4,7 +4,6 @@ from datetime import datetime, timezone
 from typing import Optional, Tuple, Any
 
 from app.logging import logger
-from app.metrics import metrics_queue_latency_seconds
 
 QueueItem = namedtuple('QueueItem', ['datetime', 'type', 'uniq_id', 'identifier', 'data'])
 
@@ -81,11 +80,16 @@ class AsyncQueue:
         async with self._lock:
             if self._items and self._items[0].datetime <= now:
                 item = self._items.pop(0)
-                delay = (now - item.datetime).total_seconds()
-                metrics_queue_latency_seconds.set(delay)
                 # Using _items list as the source of truth for ordering and content
                 return item.type, item.uniq_id, item.identifier, item.data
         return None, None, None, None
+
+    async def get_first_item_datetime(self) -> Optional[datetime]:
+        """Get datetime of the next item that's ready to be processed (if any)."""
+        async with self._lock:
+            if self._items:
+                return self._items[0].datetime
+        return None
 
     async def serialize(self) -> list:
         """Serialize queue items for API response"""

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from typing import Optional, Tuple, Any
 
 from app.logging import logger
-from app.metrics import queue_delay_seconds
+from app.metrics import metrics_queue_latency_seconds
 
 QueueItem = namedtuple('QueueItem', ['datetime', 'type', 'uniq_id', 'identifier', 'data'])
 
@@ -82,7 +82,7 @@ class AsyncQueue:
             if self._items and self._items[0].datetime <= now:
                 item = self._items.pop(0)
                 delay = (now - item.datetime).total_seconds()
-                queue_delay_seconds.set(delay)
+                metrics_queue_latency_seconds.set(delay)
                 # Using _items list as the source of truth for ordering and content
                 return item.type, item.uniq_id, item.identifier, item.data
         return None, None, None, None

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import Optional, Tuple, Any
 
 from app.logging import logger
+from app.metrics import queue_delay_seconds
 
 QueueItem = namedtuple('QueueItem', ['datetime', 'type', 'uniq_id', 'identifier', 'data'])
 
@@ -80,6 +81,8 @@ class AsyncQueue:
         async with self._lock:
             if self._items and self._items[0].datetime <= now:
                 item = self._items.pop(0)
+                delay = (now - item.datetime).total_seconds()
+                queue_delay_seconds.set(delay)
                 # Using _items list as the source of truth for ordering and content
                 return item.type, item.uniq_id, item.identifier, item.data
         return None, None, None, None

--- a/main.py
+++ b/main.py
@@ -18,7 +18,7 @@ from app.im.channel_manager import ChannelManager
 from app.im.helpers import get_application
 from app.incident.incidents import Incidents
 from app.logging import logger, configure_uvicorn_logging
-from app.metrics import metrics_status, metrics_collector
+from app.metrics import MetricsCollector
 from app.middleware import StandbyMiddleware, is_standby_mode, service_unavailable_response
 from app.queue.manager import AsyncQueueManager
 from app.queue.queue import AsyncQueue
@@ -121,7 +121,7 @@ async def initialize_primary_server(fastapi_app: FastAPI, file_lock: FileLock) -
 
         queue_manager.start_processing()
         fastapi_app.state.is_standby = False
-        metrics_status.set(1)
+        fastapi_app.state.metrics.status.set(1)
         logger.info('IMPulse started as primary server!')
         return True
     except Exception as e:
@@ -136,11 +136,14 @@ async def lifespan(fastapi_app: FastAPI):
     file_lock = FileLock()
     locked = file_lock.is_locked()
     shutdown_event = asyncio.Event()
+    metrics_collector = MetricsCollector()
 
     # Store file_lock and standby state early so /readyz endpoint can access them
     fastapi_app.state.file_lock = file_lock
     fastapi_app.state.is_standby = locked
     fastapi_app.state.queue_manager = None
+    fastapi_app.state.queue = AsyncQueue()
+    fastapi_app.state.metrics = metrics_collector
     
     async def wait_and_become_primary():
         """Background task to wait for lock and become primary server."""
@@ -162,7 +165,7 @@ async def lifespan(fastapi_app: FastAPI):
     if locked:
         logger.info("Another IMPulse instance is running, working as standby server")
         hostname, pid, _ = file_lock.get_lock_info()
-        metrics_status.set(0)
+        fastapi_app.state.metrics.status.set(0)
         logger.debug(f"Lock file is used by hostname {hostname}, PID {pid}")
         logger.info('IMPulse started in standby mode!')
         unlock_task = asyncio.create_task(wait_and_become_primary())
@@ -367,7 +370,8 @@ app.include_router(router)
 @metrics_router.get("/metrics")
 async def get_metrics(request: Request):
     """Prometheus metrics endpoint"""
-    queue = getattr(request.app.state, 'queue', None)
+    queue = request.app.state.queue
+    metrics_collector = request.app.state.metrics
     return await metrics_collector.generate_metrics_response(queue)
 
 # Include metrics router for monitoring

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ from app.im.channel_manager import ChannelManager
 from app.im.helpers import get_application
 from app.incident.incidents import Incidents
 from app.logging import logger, configure_uvicorn_logging
-from app.metrics import impulse_status
+from app.metrics import metrics_status
 from app.middleware import StandbyMiddleware, is_standby_mode, service_unavailable_response
 from app.queue.manager import AsyncQueueManager
 from app.queue.queue import AsyncQueue
@@ -122,7 +122,7 @@ async def initialize_primary_server(fastapi_app: FastAPI, file_lock: FileLock) -
 
         queue_manager.start_processing()
         fastapi_app.state.is_standby = False
-        impulse_status.set(1)
+        metrics_status.set(1)
         logger.info('IMPulse started as primary server!')
         return True
     except Exception as e:
@@ -163,7 +163,7 @@ async def lifespan(fastapi_app: FastAPI):
     if locked:
         logger.info("Another IMPulse instance is running, working as standby server")
         hostname, pid, _ = file_lock.get_lock_info()
-        impulse_status.set(0)
+        metrics_status.set(0)
         logger.debug(f"Lock file is used by hostname {hostname}, PID {pid}")
         logger.info('IMPulse started in standby mode!')
         unlock_task = asyncio.create_task(wait_and_become_primary())

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect, HTTPExcept
 from fastapi.responses import HTMLResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
 
 from app.config.config import get_config, reload_config
 from app.config.validation import MessengerType
@@ -219,6 +220,7 @@ app.add_middleware(StandbyMiddleware)
 config = get_config()
 http_prefix = config.http_prefix
 router = APIRouter(prefix=http_prefix)
+metrics_router = APIRouter()
 
 
 def get_live(request: Request):
@@ -358,6 +360,19 @@ async def websocket_endpoint(websocket: WebSocket):
 
 # Include router in the app
 app.include_router(router)
+
+
+@metrics_router.get("/metrics")
+async def get_metrics():
+    """Prometheus metrics endpoint"""
+    return Response(
+        content=generate_latest(),
+        media_type=CONTENT_TYPE_LATEST
+    )
+
+
+# Include metrics router for monitoring
+app.include_router(metrics_router)
 
 
 def parse_arguments():

--- a/main.py
+++ b/main.py
@@ -10,7 +10,6 @@ from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect, HTTPExcept
 from fastapi.responses import HTMLResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
 
 from app.config.config import get_config, reload_config
 from app.config.validation import MessengerType
@@ -19,7 +18,7 @@ from app.im.channel_manager import ChannelManager
 from app.im.helpers import get_application
 from app.incident.incidents import Incidents
 from app.logging import logger, configure_uvicorn_logging
-from app.metrics import metrics_status
+from app.metrics import metrics_status, metrics_collector
 from app.middleware import StandbyMiddleware, is_standby_mode, service_unavailable_response
 from app.queue.manager import AsyncQueueManager
 from app.queue.queue import AsyncQueue
@@ -366,13 +365,10 @@ app.include_router(router)
 
 
 @metrics_router.get("/metrics")
-async def get_metrics():
+async def get_metrics(request: Request):
     """Prometheus metrics endpoint"""
-    return Response(
-        content=generate_latest(),
-        media_type=CONTENT_TYPE_LATEST
-    )
-
+    queue = getattr(request.app.state, 'queue', None)
+    return await metrics_collector.generate_metrics_response(queue)
 
 # Include metrics router for monitoring
 app.include_router(metrics_router)

--- a/main.py
+++ b/main.py
@@ -10,7 +10,6 @@ from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect, HTTPExcept
 from fastapi.responses import HTMLResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-
 from app.config.config import get_config, reload_config
 from app.config.validation import MessengerType
 from app.file_lock import FileLock
@@ -18,7 +17,7 @@ from app.im.channel_manager import ChannelManager
 from app.im.helpers import get_application
 from app.incident.incidents import Incidents
 from app.logging import logger, configure_uvicorn_logging
-from app.metrics import MetricsCollector
+from app.metrics import STATUS, generate_metrics_response
 from app.middleware import StandbyMiddleware, is_standby_mode, service_unavailable_response
 from app.queue.manager import AsyncQueueManager
 from app.queue.queue import AsyncQueue
@@ -121,7 +120,7 @@ async def initialize_primary_server(fastapi_app: FastAPI, file_lock: FileLock) -
 
         queue_manager.start_processing()
         fastapi_app.state.is_standby = False
-        fastapi_app.state.metrics.status.set(1)
+        STATUS.set(1)
         logger.info('IMPulse started as primary server!')
         return True
     except Exception as e:
@@ -136,14 +135,12 @@ async def lifespan(fastapi_app: FastAPI):
     file_lock = FileLock()
     locked = file_lock.is_locked()
     shutdown_event = asyncio.Event()
-    metrics_collector = MetricsCollector()
 
     # Store file_lock and standby state early so /readyz endpoint can access them
     fastapi_app.state.file_lock = file_lock
     fastapi_app.state.is_standby = locked
     fastapi_app.state.queue_manager = None
     fastapi_app.state.queue = AsyncQueue()
-    fastapi_app.state.metrics = metrics_collector
     
     async def wait_and_become_primary():
         """Background task to wait for lock and become primary server."""
@@ -165,7 +162,7 @@ async def lifespan(fastapi_app: FastAPI):
     if locked:
         logger.info("Another IMPulse instance is running, working as standby server")
         hostname, pid, _ = file_lock.get_lock_info()
-        fastapi_app.state.metrics.status.set(0)
+        STATUS.set(0)
         logger.debug(f"Lock file is used by hostname {hostname}, PID {pid}")
         logger.info('IMPulse started in standby mode!')
         unlock_task = asyncio.create_task(wait_and_become_primary())
@@ -225,7 +222,6 @@ app.add_middleware(StandbyMiddleware)
 config = get_config()
 http_prefix = config.http_prefix
 router = APIRouter(prefix=http_prefix)
-metrics_router = APIRouter()
 
 
 def get_live(request: Request):
@@ -254,8 +250,15 @@ def get_ready(request: Request):
         media_type="text/plain"
     )
 
+@router.get("/metrics")
+async def get_metrics(request: Request):
+    """Prometheus metrics endpoint"""
+    queue = request.app.state.queue
+    return await generate_metrics_response(queue)
+
 app.add_api_route(f"{http_prefix}/livez", get_live, methods=["GET"])
 app.add_api_route(f"{http_prefix}/readyz", get_ready, methods=["GET"])
+app.add_api_route(f"{http_prefix}/metrics", get_metrics, methods=["GET"])
 
 if get_config().ui_config:
     if http_prefix:
@@ -365,18 +368,6 @@ async def websocket_endpoint(websocket: WebSocket):
 
 # Include router in the app
 app.include_router(router)
-
-
-@metrics_router.get("/metrics")
-async def get_metrics(request: Request):
-    """Prometheus metrics endpoint"""
-    queue = request.app.state.queue
-    metrics_collector = request.app.state.metrics
-    return await metrics_collector.generate_metrics_response(queue)
-
-# Include metrics router for monitoring
-app.include_router(metrics_router)
-
 
 def parse_arguments():
     """Parse command line arguments"""

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ from app.im.channel_manager import ChannelManager
 from app.im.helpers import get_application
 from app.incident.incidents import Incidents
 from app.logging import logger, configure_uvicorn_logging
+from app.metrics import impulse_status
 from app.middleware import StandbyMiddleware, is_standby_mode, service_unavailable_response
 from app.queue.manager import AsyncQueueManager
 from app.queue.queue import AsyncQueue
@@ -121,6 +122,7 @@ async def initialize_primary_server(fastapi_app: FastAPI, file_lock: FileLock) -
 
         queue_manager.start_processing()
         fastapi_app.state.is_standby = False
+        impulse_status.set(1)
         logger.info('IMPulse started as primary server!')
         return True
     except Exception as e:
@@ -161,6 +163,7 @@ async def lifespan(fastapi_app: FastAPI):
     if locked:
         logger.info("Another IMPulse instance is running, working as standby server")
         hostname, pid, _ = file_lock.get_lock_info()
+        impulse_status.set(0)
         logger.debug(f"Lock file is used by hostname {hostname}, PID {pid}")
         logger.info('IMPulse started in standby mode!')
         unlock_task = asyncio.create_task(wait_and_become_primary())

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ requests~=2.32.3
 aiohttp~=3.12.10
 aiohttp-retry~=2.8.3
 Jinja2~=3.1.3
+prometheus_client~=0.23.1
 pydantic~=2.11.7
 PyYAML~=6.0.1
 python-dotenv~=1.0.1


### PR DESCRIPTION
Add Prometheus metrics:

1) "impulse_messenger_api_request_duration_seconds" Histogram metric for RateLimitedClient.request().

Implemented as an async context manager to:
- measure HTTP request duration (buckets: 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, +Inf);
- record messenger_type, status (1-5xx, no_response) and error (none, connection_failed, timeout, unknown) labels .

2) "impulse_status" Gauge metric.

Check whether instance is primary (1.0) or standby (0.0). Include /metrics endpoint to StandbyMiddleware.dispatch() to let this endpoint be available when in standby mode.

3) "impulse_queue_latency_seconds" Gauge metric for AsyncQueue.get_next_ready_item().

Calculate delay between current time and QueueItem.datetime when item is retrieved from queue.

