### PR TITLE
397 add deployment strategy support to Helm chart (#397)

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -6,6 +6,14 @@ metadata:
     {{- include "impulse.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount | default 1 }}
+  {{- with .Values.strategy }}
+  strategy:
+    type: {{ .type }}
+    {{- if and (eq .type "RollingUpdate") .rollingUpdate }}
+    rollingUpdate:
+      {{- toYaml .rollingUpdate | nindent 6 }}
+    {{- end }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "impulse.selectorLabels" . | nindent 6 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,6 +4,15 @@
 # Should not be changed until IMPulse supports multiple replicas
 # replicaCount: 1
 
+# Deployment strategy
+# Use "Recreate" to kill all existing pods before creating new ones
+# Use "RollingUpdate" for zero-downtime deployments (default)
+strategy:
+  type: RollingUpdate
+  # rollingUpdate:
+  #   maxSurge: 1
+  #   maxUnavailable: 0
+
 image:
   repository: ghcr.io/eslupmi/impulse
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Add configurable deployment strategy (Recreate/RollingUpdate) to allow users to control pod replacement behavior during updates.

Closes #397