### PR TITLE
Add apply_current_inhibition method to InhibitionManager

### DIFF
--- a/app/inhibition/manager.py
+++ b/app/inhibition/manager.py
@@ -77,6 +77,9 @@ class InhibitionManager:
                 await self.process_incident(incident)
                 continue
 
+            if incident.childs or incident.parents:
+                await self._cleanup_untracked_incident(incident)
+
         logger.debug("Applied current inhibition to existing incidents")
     
     def would_be_inhibited(self, incident: 'Incident') -> bool:
@@ -174,24 +177,18 @@ class InhibitionManager:
         await self._unfreeze_target_if_no_parents(incident)
 
     async def _process_incident_for_rule(self, incident: 'Incident', rule_idx: int, rule: InhibitionRule):
-        done_1 = False
-        done_2 = False
         if rule.is_target(incident):
-            done_1 = True
             self.targets[rule_idx].add(incident.uniq_id)
             await self._freeze_matching_targets(
                 incident, self.sources[rule_idx], rule, incident_is_target=True
             )
         if rule.is_source(incident):
-            done_2 = True
             self.sources[rule_idx].add(incident.uniq_id)
             done = await self._freeze_matching_targets(
                 incident, self.targets[rule_idx], rule, incident_is_target=False
             )
             if done and self.application.type != MessengerType.TELEGRAM:
                 await self.application.update_incident_message(incident)
-        if not done_1 and not done_2:
-            await self._cleanup_untracked_incident(incident)
 
     async def _freeze_matching_targets(
         self,

--- a/app/inhibition/manager.py
+++ b/app/inhibition/manager.py
@@ -77,9 +77,6 @@ class InhibitionManager:
                 await self.process_incident(incident)
                 continue
 
-            if incident.childs or incident.parents:
-                await self._cleanup_untracked_incident(incident)
-
         logger.debug("Applied current inhibition to existing incidents")
     
     def would_be_inhibited(self, incident: 'Incident') -> bool:
@@ -177,18 +174,24 @@ class InhibitionManager:
         await self._unfreeze_target_if_no_parents(incident)
 
     async def _process_incident_for_rule(self, incident: 'Incident', rule_idx: int, rule: InhibitionRule):
+        done_1 = False
+        done_2 = False
         if rule.is_target(incident):
+            done_1 = True
             self.targets[rule_idx].add(incident.uniq_id)
             await self._freeze_matching_targets(
                 incident, self.sources[rule_idx], rule, incident_is_target=True
             )
         if rule.is_source(incident):
+            done_2 = True
             self.sources[rule_idx].add(incident.uniq_id)
             done = await self._freeze_matching_targets(
                 incident, self.targets[rule_idx], rule, incident_is_target=False
             )
             if done and self.application.type != MessengerType.TELEGRAM:
                 await self.application.update_incident_message(incident)
+        if not done_1 and not done_2:
+            await self._cleanup_untracked_incident(incident)
 
     async def _freeze_matching_targets(
         self,

--- a/app/inhibition/manager.py
+++ b/app/inhibition/manager.py
@@ -65,22 +65,130 @@ class InhibitionManager:
     async def apply_current_inhibition(self):
         logger.debug("Applying current inhibition to existing incidents")
 
-        source_ids = set().union(*self.sources.values()) if self.sources else set()
-        target_ids = set().union(*self.targets.values()) if self.targets else set()
+        required_children_by_source, required_parents_by_target, tracked_ids = self._build_required_inhibition_graph()
+        await self._reconcile_existing_inhibition_links(required_children_by_source, required_parents_by_target)
 
-        for uniq_id in self.incidents.active_map.values():
-            incident = self.incidents.uniq_ids.get(uniq_id)
-            if not incident:
-                continue
+        updated_sources = await self._apply_missing_required_links(required_children_by_source)
+        if updated_sources and self.application.type != MessengerType.TELEGRAM:
+            await self._update_sources_messages(updated_sources)
 
-            if uniq_id in source_ids or uniq_id in target_ids:
-                await self.process_incident(incident)
-                continue
-
-            if incident.childs or incident.parents:
-                await self._cleanup_untracked_incident(incident)
+        await self._cleanup_untracked_inhibition(tracked_ids)
 
         logger.debug("Applied current inhibition to existing incidents")
+
+    def _build_required_inhibition_graph(self):
+        required_children_by_source: Dict[str, Set[str]] = {}
+        required_parents_by_target: Dict[str, Set[str]] = {}
+        tracked_ids: Set[str] = set()
+
+        for rule_idx, rule in enumerate(self.rules):
+            source_ids = self.sources[rule_idx]
+            target_ids = self.targets[rule_idx]
+            tracked_ids.update(source_ids)
+            tracked_ids.update(target_ids)
+
+            for source_uniq_id in source_ids:
+                source = self.incidents.uniq_ids.get(source_uniq_id)
+                if not source or source.status == 'resolved':
+                    continue
+
+                for target_uniq_id in target_ids:
+                    if source_uniq_id == target_uniq_id:
+                        continue
+
+                    target = self.incidents.uniq_ids.get(target_uniq_id)
+                    if not target:
+                        continue
+
+                    if not rule.equal_labels_match(source, target):
+                        continue
+
+                    required_children_by_source.setdefault(source_uniq_id, set()).add(target_uniq_id)
+                    required_parents_by_target.setdefault(target_uniq_id, set()).add(source_uniq_id)
+
+        return required_children_by_source, required_parents_by_target, tracked_ids
+
+    async def _reconcile_existing_inhibition_links(
+        self,
+        required_children_by_source: Dict[str, Set[str]],
+        required_parents_by_target: Dict[str, Set[str]]
+    ):
+        for incident in self._iter_active_incidents():
+            await self._reconcile_source_links(incident, required_children_by_source.get(incident.uniq_id, set()))
+            await self._reconcile_target_links(incident, required_parents_by_target.get(incident.uniq_id, set()))
+
+    async def _reconcile_source_links(self, source: 'Incident', required_childs: Set[str]):
+        source_changed = False
+
+        for child_uniq_id in list(source.childs):
+            if child_uniq_id in required_childs:
+                continue
+
+            source.childs.remove(child_uniq_id)
+            source_changed = True
+
+            child = self.incidents.uniq_ids.get(child_uniq_id)
+            if child and source.uniq_id in child.parents:
+                child.parents.remove(source.uniq_id)
+                child.dump()
+                await self._unfreeze_target_if_no_parents(child)
+
+        if source_changed:
+            source.dump()
+
+    async def _reconcile_target_links(self, target: 'Incident', required_parents: Set[str]):
+        target_changed = False
+
+        for parent_uniq_id in list(target.parents):
+            if parent_uniq_id in required_parents:
+                continue
+
+            target.parents.remove(parent_uniq_id)
+            target_changed = True
+
+            parent = self.incidents.uniq_ids.get(parent_uniq_id)
+            if parent and target.uniq_id in parent.childs:
+                parent.childs.remove(target.uniq_id)
+                parent.dump()
+
+        if target_changed:
+            target.dump()
+            await self._unfreeze_target_if_no_parents(target)
+
+    async def _apply_missing_required_links(self, required_children_by_source: Dict[str, Set[str]]) -> Set[str]:
+        updated_sources: Set[str] = set()
+
+        for source_uniq_id, target_uniq_ids in required_children_by_source.items():
+            source = self.incidents.uniq_ids.get(source_uniq_id)
+            if not source:
+                continue
+
+            for target_uniq_id in target_uniq_ids:
+                target = self.incidents.uniq_ids.get(target_uniq_id)
+                if not target:
+                    continue
+
+                if await self._freeze_target(source, target):
+                    updated_sources.add(source_uniq_id)
+
+        return updated_sources
+
+    async def _update_sources_messages(self, source_ids: Set[str]):
+        for source_uniq_id in source_ids:
+            source = self.incidents.uniq_ids.get(source_uniq_id)
+            if source:
+                await self.application.update_incident_message(source)
+
+    async def _cleanup_untracked_inhibition(self, tracked_ids: Set[str]):
+        for incident in self._iter_active_incidents():
+            if incident.uniq_id not in tracked_ids and (incident.childs or incident.parents or incident.frozen_by_inhibition):
+                await self._cleanup_untracked_incident(incident)
+
+    def _iter_active_incidents(self):
+        for uniq_id in self.incidents.active_map.values():
+            incident = self.incidents.uniq_ids.get(uniq_id)
+            if incident:
+                yield incident
     
     def would_be_inhibited(self, incident: 'Incident') -> bool:
         if not self.rules:

--- a/app/inhibition/manager.py
+++ b/app/inhibition/manager.py
@@ -61,6 +61,26 @@ class InhibitionManager:
         logger.debug("Inhibition state restoration complete",
                    extra={'sources_count': sum(len(s) for s in self.sources.values()),
                          'targets_count': sum(len(t) for t in self.targets.values())})
+
+    async def apply_current_inhibition(self):
+        logger.debug("Applying current inhibition to existing incidents")
+
+        source_ids = set().union(*self.sources.values()) if self.sources else set()
+        target_ids = set().union(*self.targets.values()) if self.targets else set()
+
+        for uniq_id in self.incidents.active_map.values():
+            incident = self.incidents.uniq_ids.get(uniq_id)
+            if not incident:
+                continue
+
+            if uniq_id in source_ids or uniq_id in target_ids:
+                await self.process_incident(incident)
+                continue
+
+            if incident.childs or incident.parents:
+                await self._cleanup_untracked_incident(incident)
+
+        logger.debug("Applied current inhibition to existing incidents")
     
     def would_be_inhibited(self, incident: 'Incident') -> bool:
         if not self.rules:
@@ -140,6 +160,21 @@ class InhibitionManager:
             await self._unfreeze_target_if_no_parents(target)
         
         source.dump()
+
+    async def _cleanup_untracked_incident(self, incident: 'Incident'):
+        if incident.childs:
+            await self._cleanup_source(incident)
+
+        if incident.parents:
+            for parent_uniq_id in list(incident.parents):
+                parent = self.incidents.uniq_ids.get(parent_uniq_id)
+                if parent and incident.uniq_id in parent.childs:
+                    parent.childs.remove(incident.uniq_id)
+                    parent.dump()
+                incident.parents.remove(parent_uniq_id)
+            incident.dump()
+
+        await self._unfreeze_target_if_no_parents(incident)
 
     async def _process_incident_for_rule(self, incident: 'Incident', rule_idx: int, rule: InhibitionRule):
         if rule.is_target(incident):

--- a/main.py
+++ b/main.py
@@ -49,6 +49,11 @@ def setup_sighup_handler(fastapi_app=None):
                 if fastapi_app and fastapi_app.state.inhibition_manager:
                     config_data = get_config()
                     fastapi_app.state.inhibition_manager.reload_rules(config_data.app.inhibit_rules or [])
+                    try:
+                        loop = asyncio.get_running_loop()
+                        loop.create_task(fastapi_app.state.inhibition_manager.apply_current_inhibition())
+                    except RuntimeError:
+                        logger.warning("No running event loop for inhibition reconciliation after reload")
         except Exception as e:
             logger.error("Configuration reload error", extra={'error': str(e)})
             logger.warning("Configuration reload aborted")

--- a/main.py
+++ b/main.py
@@ -118,6 +118,7 @@ async def initialize_primary_server(fastapi_app: FastAPI, file_lock: FileLock) -
             queue=queue
         )
         inhibition_manager.restore_from_incidents()
+        await inhibition_manager.apply_current_inhibition()
 
         user_scheduler = UserUpdateScheduler(queue, messenger.type.value)
         messenger.configure_scheduler(user_scheduler)

--- a/tests/test_inhibition/test_manager.py
+++ b/tests/test_inhibition/test_manager.py
@@ -29,6 +29,7 @@ class TestInhibitionManager:
         """Create mock application."""
         app = create_mock_application()
         app.update_thread = AsyncMock()
+        app.update_incident_message = AsyncMock()
         app.body_template = Mock()
         app.body_template.form_message = Mock(return_value="body")
         app.header_template = Mock()
@@ -391,6 +392,67 @@ class TestInhibitionManager:
         assert "firing-1" in inhibition_manager.sources[0]
         assert "unknown-1" in inhibition_manager.sources[0]
         assert "resolved-1" in inhibition_manager.sources[0]
+
+    @pytest.mark.asyncio
+    async def test_apply_current_inhibition_no_rules(self, empty_inhibition_manager, mock_incidents):
+        """Test apply_current_inhibition with no rules does nothing."""
+        incident = self._create_mock_incident("inc-1", "critical", "api")
+        mock_incidents.active_map = {"uuid-inc-1": "inc-1"}
+        mock_incidents.uniq_ids = {"inc-1": incident}
+
+        await empty_inhibition_manager.apply_current_inhibition()
+
+        incident.freeze_by_inhibition.assert_not_called()
+        empty_inhibition_manager.queue.delete_by_id.assert_not_awaited()
+        empty_inhibition_manager.application.update_incident_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_apply_current_inhibition_processes_tracked_incidents(self, inhibition_manager, mock_incidents):
+        """Test apply_current_inhibition processes incidents tracked by current rules."""
+        source = self._create_mock_incident("source-1", "critical", "api")
+        target = self._create_mock_incident("target-1", "warning", "api")
+        mock_incidents.active_map = {"uuid-source-1": "source-1", "uuid-target-1": "target-1"}
+        mock_incidents.uniq_ids = {"source-1": source, "target-1": target}
+        inhibition_manager.restore_from_incidents()
+
+        await inhibition_manager.apply_current_inhibition()
+
+        assert "target-1" in source.childs
+        assert "source-1" in target.parents
+        target.freeze_by_inhibition.assert_called_once()
+        inhibition_manager.queue.delete_by_id.assert_awaited_once_with(
+            "target-1", delete_steps=True, delete_status=False
+        )
+
+    @pytest.mark.asyncio
+    @patch("app.inhibition.manager.unfreeze_incident", new_callable=AsyncMock)
+    async def test_apply_current_inhibition_cleans_untracked_state(
+        self, mock_unfreeze_incident, inhibition_manager, mock_incidents
+    ):
+        """Test stale inhibition links are cleaned and stale frozen target is unfrozen."""
+        async def _unfreeze_side_effect(incident, _application, _queue):
+            incident.frozen_by_inhibition = False
+
+        mock_unfreeze_incident.side_effect = _unfreeze_side_effect
+
+        source = self._create_mock_incident("source-1", "critical", "api", childs=["target-1"])
+        target = self._create_mock_incident(
+            "target-1", "warning", "api", parents=["source-1"], frozen_by_inhibition=True
+        )
+
+        # No current rules match these incidents, but stale inhibition links exist.
+        target.payload["commonLabels"]["severity"] = "info"
+        mock_incidents.active_map = {"uuid-source-1": "source-1", "uuid-target-1": "target-1"}
+        mock_incidents.uniq_ids = {"source-1": source, "target-1": target}
+        inhibition_manager.restore_from_incidents()
+
+        await inhibition_manager.apply_current_inhibition()
+
+        target.freeze_by_inhibition.assert_not_called()
+        assert source.childs == []
+        assert target.parents == []
+        mock_unfreeze_incident.assert_awaited_once_with(target, inhibition_manager.application, inhibition_manager.queue)
+        inhibition_manager.application.update_incident_message.assert_awaited_once_with(target)
 
     # Reload Rules Tests
 

--- a/tests/test_inhibition/test_manager.py
+++ b/tests/test_inhibition/test_manager.py
@@ -454,6 +454,100 @@ class TestInhibitionManager:
         mock_unfreeze_incident.assert_awaited_once_with(target, inhibition_manager.application, inhibition_manager.queue)
         inhibition_manager.application.update_incident_message.assert_awaited_once_with(target)
 
+    @pytest.mark.asyncio
+    @patch("app.inhibition.manager.unfreeze_incident", new_callable=AsyncMock)
+    async def test_apply_current_inhibition_cleans_tracked_links_after_equal_change(
+        self, mock_unfreeze_incident, inhibition_manager, mock_incidents
+    ):
+        """Test stale links are removed when incidents remain tracked but equal labels no longer match."""
+        async def _unfreeze_side_effect(incident, _application, _queue):
+            incident.frozen_by_inhibition = False
+
+        mock_unfreeze_incident.side_effect = _unfreeze_side_effect
+
+        source = self._create_mock_incident("source-1", "critical", "api", childs=["target-1"])
+        target = self._create_mock_incident(
+            "target-1", "warning", "api", parents=["source-1"], frozen_by_inhibition=True
+        )
+        target.payload["commonLabels"]["service"] = "web"
+
+        mock_incidents.active_map = {"uuid-source-1": "source-1", "uuid-target-1": "target-1"}
+        mock_incidents.uniq_ids = {"source-1": source, "target-1": target}
+        inhibition_manager.restore_from_incidents()
+
+        await inhibition_manager.apply_current_inhibition()
+
+        assert source.childs == []
+        assert target.parents == []
+        target.freeze_by_inhibition.assert_not_called()
+        mock_unfreeze_incident.assert_awaited_once_with(target, inhibition_manager.application, inhibition_manager.queue)
+
+    @pytest.mark.asyncio
+    @patch("app.inhibition.manager.unfreeze_incident", new_callable=AsyncMock)
+    async def test_apply_current_inhibition_keeps_valid_existing_link(
+        self, mock_unfreeze_incident, inhibition_manager, mock_incidents
+    ):
+        """Test existing parent-child link is preserved when still valid under current rules."""
+        source = self._create_mock_incident("source-1", "critical", "api", childs=["target-1"])
+        target = self._create_mock_incident(
+            "target-1", "warning", "api", parents=["source-1"], frozen_by_inhibition=True
+        )
+
+        mock_incidents.active_map = {"uuid-source-1": "source-1", "uuid-target-1": "target-1"}
+        mock_incidents.uniq_ids = {"source-1": source, "target-1": target}
+        inhibition_manager.restore_from_incidents()
+
+        await inhibition_manager.apply_current_inhibition()
+
+        assert source.childs == ["target-1"]
+        assert target.parents == ["source-1"]
+        target.freeze_by_inhibition.assert_not_called()
+        inhibition_manager.queue.delete_by_id.assert_not_awaited()
+        mock_unfreeze_incident.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("app.inhibition.manager.unfreeze_incident", new_callable=AsyncMock)
+    async def test_apply_current_inhibition_keeps_link_if_any_rule_matches(
+        self, mock_unfreeze_incident, mock_queue, mock_application, mock_incidents
+    ):
+        """Test link remains valid if at least one rule still matches equal labels."""
+        rule_service = Mock(spec=InhibitRule)
+        rule_service.source_matchers = ['severity = "critical"']
+        rule_service.target_matchers = ['severity = "warning"']
+        rule_service.equal = ['service']
+
+        rule_cluster = Mock(spec=InhibitRule)
+        rule_cluster.source_matchers = ['severity = "critical"']
+        rule_cluster.target_matchers = ['severity = "warning"']
+        rule_cluster.equal = ['cluster']
+
+        manager = InhibitionManager(
+            rules=[rule_service, rule_cluster],
+            incidents=mock_incidents,
+            application=mock_application,
+            queue=mock_queue
+        )
+
+        source = self._create_mock_incident("source-1", "critical", "api", childs=["target-1"])
+        target = self._create_mock_incident(
+            "target-1", "warning", "api", parents=["source-1"], frozen_by_inhibition=True
+        )
+        target.payload["commonLabels"]["service"] = "web"
+        source.payload["commonLabels"]["cluster"] = "prod"
+        target.payload["commonLabels"]["cluster"] = "prod"
+
+        mock_incidents.active_map = {"uuid-source-1": "source-1", "uuid-target-1": "target-1"}
+        mock_incidents.uniq_ids = {"source-1": source, "target-1": target}
+        manager.restore_from_incidents()
+
+        await manager.apply_current_inhibition()
+
+        assert source.childs == ["target-1"]
+        assert target.parents == ["source-1"]
+        target.freeze_by_inhibition.assert_not_called()
+        mock_queue.delete_by_id.assert_not_awaited()
+        mock_unfreeze_incident.assert_not_awaited()
+
     # Reload Rules Tests
 
     def test_reload_rules(self, inhibition_manager, mock_incidents):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -38,6 +38,7 @@ class TestMainApplication:
             # Setup mock inhibition manager
             mock_inhibition_manager = Mock()
             mock_inhibition_manager.restore_from_incidents = Mock()
+            mock_inhibition_manager.apply_current_inhibition = AsyncMock()
             mock_inhibition_manager_class.return_value = mock_inhibition_manager
             
             # Setup mock config

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -272,6 +272,38 @@ class TestSignalHandlers:
         mock_logger.info.assert_any_call("Reloading configuration")
         mock_logger.info.assert_any_call("Configuration reloaded")
 
+    @patch('main.get_config')
+    @patch('main.reload_config')
+    @patch('main.logger')
+    def test_sighup_handler_schedules_inhibition_reconciliation(
+        self, mock_logger, mock_reload_config, mock_get_config
+    ):
+        """Test SIGHUP reload schedules apply_current_inhibition when manager is present."""
+        mock_reload_config.return_value = True
+        mock_config = Mock()
+        mock_config.app.inhibit_rules = []
+        mock_get_config.return_value = mock_config
+
+        mock_manager = Mock()
+        mock_manager.reload_rules = Mock()
+        reconcile_coro = Mock()
+        mock_manager.apply_current_inhibition = Mock(return_value=reconcile_coro)
+        mock_app = Mock()
+        mock_app.state = Mock()
+        mock_app.state.inhibition_manager = mock_manager
+        mock_loop = Mock()
+
+        with patch('main.hasattr', return_value=True), \
+                patch('main.signal') as mock_signal, \
+                patch('main.asyncio.get_running_loop', return_value=mock_loop):
+            main.setup_sighup_handler(mock_app)
+            handler = mock_signal.signal.call_args[0][1]
+            handler(None, None)
+
+        mock_manager.reload_rules.assert_called_once_with([])
+        mock_manager.apply_current_inhibition.assert_called_once()
+        mock_loop.create_task.assert_called_once_with(reconcile_coro)
+
     @patch('main.reload_config')
     @patch('main.logger')
     def test_sighup_handler_error(self, mock_logger, mock_reload_config):


### PR DESCRIPTION
- Implemented apply_current_inhibition to process existing incidents based on current inhibition rules.
- Added logic to clean up untracked incidents and manage their relationships.
- Updated main application to call apply_current_inhibition during server initialization.
- Enhanced tests to cover various scenarios for apply_current_inhibition, ensuring proper functionality and state management.